### PR TITLE
We need to push to our private Gem repo

### DIFF
--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -31,15 +31,6 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.required_ruby_version = ">= 2.5.0"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files = %w{Rakefile LICENSE README.md} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
     Dir.glob("*.gemspec") +


### PR DESCRIPTION
This should fix our

```
$ gem push chef-apply-0.1.1.gem --host http://***:8081/api/gems/omnibus-gems-local --key *** 2>&1

ERROR:  While executing gem ... (URI::InvalidURIError)
    bad URI(is not URI?): TODO: Set to 'http://mygemserver.com'
```

error from Expeditor