### PR TITLE
Raise error if installed Chef version is lower than 14.1.1

### DIFF
--- a/lib/chef_apply/action/install_chef/base.rb
+++ b/lib/chef_apply/action/install_chef/base.rb
@@ -20,7 +20,7 @@ require "fileutils"
 
 module ChefApply::Action::InstallChef
   class Base < ChefApply::Action::Base
-    MIN_CHEF_VERSION = Gem::Version.new("13.0.0")
+    MIN_CHEF_VERSION = Gem::Version.new("14.1.1")
 
     def perform_action
       if target_host.installed_chef_version >= MIN_CHEF_VERSION


### PR DESCRIPTION
This is a bug I accidently committed when doing the move to this repo

Signed-off-by: tyler-ball <tball@chef.io>