### PR TITLE
[SHACK-295] Chef 13 on Linux requires absolute paths for config location

### DIFF
--- a/lib/chef_apply/action/base.rb
+++ b/lib/chef_apply/action/base.rb
@@ -84,6 +84,10 @@ module ChefApply
       # Chef will try 'downloading' the policy from the internet unless we pass it a valid, local file
       # in the working directory. By pointing it at a local file it will just copy it instead of trying
       # to download it.
+      #
+      # Chef 13 on Linux requires full path specifiers for --config and --recipe-url while on Chef 13 and 14 on
+      # Windows must use relative specifiers to prevent URI from causing an error
+      # (https://github.com/chef/chef/pull/7223/files).
       def run_chef(working_dir, config, policy)
         case family
         when :windows
@@ -96,7 +100,7 @@ module ChefApply
         else
           # cd is shell a builtin, so much call bash. This also means all commands are executed
           # with sudo (as long as we are hardcoding our sudo use)
-          "bash -c 'cd #{working_dir}; chef-client -z --config #{config} --recipe-url #{policy}'"
+          "bash -c 'cd #{working_dir}; chef-client -z --config #{File.join(working_dir, config)} --recipe-url #{File.join(working_dir, policy)}'"
         end
       end
 

--- a/spec/unit/action/base_spec.rb
+++ b/spec/unit/action/base_spec.rb
@@ -62,19 +62,28 @@ RSpec.describe ChefApply::Action::Base do
         expect(action.send(path)).to be_a(String)
       end
     end
-
-    it "correctly returns chef run string" do
-      expect(action.run_chef(nil, nil, nil)).to be_a(String)
-    end
   end
 
   describe "when connecting to a windows target" do
     include_examples "check path fetching"
+
+    it "correctly returns chef run string" do
+      expect(action.run_chef("a", "b", "c")).to eq(
+        "Set-Location -Path a; " \
+        "chef-client -z --config b --recipe-url c | Out-Null; " \
+        "Set-Location C:/; " \
+        "exit $LASTEXITCODE"
+      )
+    end
   end
 
   describe "when connecting to a non-windows target" do
     let(:family) { "linux" }
     include_examples "check path fetching"
+
+    it "correctly returns chef run string" do
+      expect(action.run_chef("a", "b", "c")).to eq("bash -c 'cd a; chef-client -z --config a/b --recipe-url a/c'")
+    end
   end
 
 end


### PR DESCRIPTION
Different version of Chef (13/14) all behave differently on different
OSes (*nix, Windows) when it comes to specifying the `chef-client
--config` option. See the comment in this change for details.

Chef throws the following error on *nix:
```
sudo chef-client -z --config workstation.rb --recipe-url cw_directory_policy-03eb35d4ce71236f6ccd809d1feec5412eaa22e9ed79bcda34e4c04a7e4faf76.tgz
Starting Chef Client, version 13.10.0
resolving cookbooks for run list: []
Synchronizing Cookbooks:
Installing Cookbook Gems:
Compiling Cookbooks...
[2018-07-13T22:08:38+00:00] WARN: Node ubuntu1 has an empty run list.
Converging 0 resources

Running handlers:
  - ChefApply::Reporter
Running handlers complete
Chef Client finished, 0/0 resources updated in 01 seconds
[2018-07-13T22:08:38+00:00] WARN: *****************************************
[2018-07-13T22:08:38+00:00] WARN: Did not find config file: /workstation.rb, using command line options.
[2018-07-13T22:08:38+00:00] WARN: *****************************************
[2018-07-13T22:08:38+00:00] FATAL: You specified --recipe-url but the value is neither a valid URL nor a path to a file that exists on disk.Please confirm the location of the tarball and try again.
```

It does not seem to recognize the arguments to `--config` or `--recipe-url` as relative paths, they must be absolute

Signed-off-by: tyler-ball <tball@chef.io>