### PR TITLE
Move chef logging configuration to Startup

### DIFF
--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -103,7 +103,6 @@ module ChefApply
         show_version
       else
         validate_params(cli_arguments)
-        configure_chef
         target_hosts = TargetResolver.new(cli_arguments.shift,
                                           parsed_options.delete(:protocol),
                                           parsed_options).targets
@@ -177,15 +176,6 @@ module ChefApply
       end
       UI::Terminal.render_parallel_jobs(TS.converge.multi_header, jobs)
       handle_job_failures(jobs)
-    end
-
-    # Now that we are leveraging Chef locally we want to perform some initial setup of it
-    def configure_chef
-      ChefConfig.logger = ChefApply::Log
-      # Setting the config isn't enough, we need to ensure the logger is initialized
-      # or automatic initialization will still go to stdout
-      Chef::Log.init(ChefApply::Log)
-      Chef::Log.level = ChefApply::Log.level
     end
 
     # The user will either specify a single resource on the command line, or a recipe.

--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -43,6 +43,9 @@ module ChefApply
       # are required.
       setup_workstation_user_directories
 
+      # Customize behavior of Ruby and any gems around error handling
+      setup_error_handling
+
       # Startup tasks that may change behavior based on configuration value
       # must be run after load_config
       load_config
@@ -120,6 +123,17 @@ module ChefApply
       FileUtils.mkdir_p(Config::WS_BASE_PATH)
       FileUtils.mkdir_p(Config.base_log_directory)
       FileUtils.mkdir_p(Config.telemetry_path)
+    end
+
+    def setup_error_handling
+      # In Ruby 2.5+ threads print out to stdout when they raise an exception. This is an agressive
+      # attempt to ensure debugging information is not lost, but in our case it is not necessary
+      # because we handle all the errors ourself. So we disable this to keep output clean.
+      # See https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
+      #
+      # We set this globally so that it applies to all threads we create - we never want any non-UI thread
+      # to render error output to the terminal.
+      Thread.report_on_exception = false
     end
 
     def load_config

--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -18,6 +18,8 @@ require "chef_apply/config"
 require "chef_apply/text"
 require "chef_apply/ui/terminal"
 require "chef_apply/telemeter/sender"
+require "chef/log"
+require "chef/config"
 module ChefApply
   class Startup
     attr_reader :argv
@@ -145,6 +147,12 @@ module ChefApply
     def setup_logging
       ChefApply::Log.setup(Config.log.location, Config.log.level.to_sym)
       ChefApply::Log.info("Initialized logger")
+
+      ChefConfig.logger = ChefApply::Log
+      # Setting the config isn't enough, we need to ensure the logger is initialized
+      # or automatic initialization will still go to stdout
+      Chef::Log.init(ChefApply::Log)
+      Chef::Log.level = ChefApply::Log.level
     end
 
     def start_chef_apply

--- a/lib/chef_apply/ui/terminal.rb
+++ b/lib/chef_apply/ui/terminal.rb
@@ -47,11 +47,6 @@ module ChefApply
 
         def init(location)
           @location = location
-          # In Ruby 2.5+ threads print out to stdout when they raise an exception. This is an agressive
-          # attempt to ensure debugging information is not lost, but in our case it is not necessary
-          # because we handle all the errors ourself. So we disable this to keep output clean.
-          # See https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-          Thread.report_on_exception = false
         end
 
         def write(msg)

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe ChefApply::CLI do
       let(:reporter) { double("reporter") }
       before(:each) do
         allow(subject).to receive(:validate_params)
-        allow(subject).to receive(:configure_chef)
         allow(subject).to receive(:generate_temp_cookbook).and_return([mock_cb, "test"])
         allow(subject).to receive(:create_local_policy).and_return(archive)
         allow(subject).to receive(:run_single_target)
@@ -156,7 +155,6 @@ RSpec.describe ChefApply::CLI do
       end
 
       it "performs the steps required to create the local policy" do
-        expect(subject).to receive(:configure_chef).ordered
         expect(subject).to receive(:generate_temp_cookbook).ordered.and_return([mock_cb, "test"])
         generating = ChefApply::Text.status.generate_policyfile.generating
         expect(ChefApply::UI::Terminal).to receive(:render_job).with(generating).and_yield(reporter)
@@ -330,23 +328,6 @@ RSpec.describe ChefApply::CLI do
         msg = ChefApply::Text.status.converge.converging_resource("directory[foo]")
         expect(actual2).to eq(msg)
       end
-    end
-  end
-
-  describe "#configure_chef" do
-    it "sets ChefConfig.logger to ChefApply.log" do
-      subject.configure_chef
-      expect(ChefConfig.logger).to eq(ChefApply::Log)
-    end
-
-    it "initializes Chef::Log" do
-      expect(Chef::Log).to receive(:init).with(ChefApply::Log)
-      subject.configure_chef
-    end
-
-    it "sets ChefConfig.logger to ChefApply.log" do
-      subject.configure_chef
-      expect(ChefConfig.logger).to eq(ChefApply::Log)
     end
   end
 

--- a/spec/unit/startup_spec.rb
+++ b/spec/unit/startup_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ChefApply::Startup do
     it "performs ordered startup tasks and invokes the CLI" do
       ordered_messages = [:first_run_tasks,
                           :setup_workstation_user_directories,
+                          :setup_error_handling,
                           :load_config,
                           :setup_logging,
                           :start_telemeter_upload,

--- a/spec/unit/startup_spec.rb
+++ b/spec/unit/startup_spec.rb
@@ -260,10 +260,13 @@ RSpec.describe ChefApply::Startup do
       ChefApply::Config.log.level = log_level
     end
 
-    it "sets up the logger with the correct log path" do
+    it "sets up the logging for ChefApply and Chef" do
       expect(ChefApply::Log).to receive(:setup).
         with(log_path, log_level)
+      expect(Chef::Log).to receive(:init).
+        with(ChefApply::Log)
       subject.setup_logging
+      expect(ChefConfig.logger).to eq(ChefApply::Log)
     end
   end
 


### PR DESCRIPTION
Rather than have some logging set up in Startup::setup_logging
and some in CLI::configure_chef, this puts both into setup_logging

This also adds setup of  error handling for threads to Startup. 