### PR TITLE
[SHACK-187] Move cookbook creation to actions

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -158,30 +158,34 @@ cli:
     connection_failed: "Connection failed: %1"
 
 status:
-  generate_policyfile:
-    generating:  Generating local policyfile...
-    success: Generated local policyfile
+  generate_temp_cookbook:
+    generating: Packaging cookbook...
+    success: Packaging cookbook... done!
+  generate_local_policy:
+    generating: Generating local policyfile...
+    exporting:  Generating local policyfile... exporting...
+    success: Generating local policyfile... exporting... done!
   install_chef:
-    installing: Installing Chef client version %1.
     checking_for_client: Checking for Chef client.
-    upgrading: Upgrading Chef client from version %1 to %2.
+    verifying: Verifying Chef client installation.
     downloading: Downloading Chef client installer into local cache.
     uploading: Uploading Chef client installer to target.
-    verifying: Verifying Chef client installation.
+    installing: Installing Chef client version %1.
+    upgrading: Upgrading Chef client from version %1 to %2.
     already_present: Chef client version %1 already installed on target.
     install_success: Successfully installed Chef client version %1
     upgrade_success: Successfully upgraded Chef client from version %1 to %2.
     failure: "An error occurred while installing Chef client: %1"
   converge:
-    multi_header: "Converging targets:"
-    converging_recipe: Converging local recipe %1 on target...
-    converging_resource: Converging %1 on target...
+    header: !!pl
+      1: Applying %2 from %3 to target.
+      n: Applying %2 from %3 to targets.
+    converging: Applying %1...
     creating_local_policy: Creating local policy...
     creating_remote_policy: Pushing remote policy to target...
     uploading_trusted_certs: Uploading local trusted certs to target...
-    running_chef: Running Chef on target...
-    success: "Successfully converged target!"
-    failure: "Failed to converge target."
+    success: "Successfully converged %1."
+    failure: "Failed to converge %1."
     reboot: "Reboot scheduled on target."
 
 # Error definitions, usage Text.e.ERR999
@@ -418,6 +422,14 @@ errors:
 
       %1
 
+  # Internal API errors - give them some formatting
+  CHEFAPI001: |
+    API error: provide either :recipe_spec or :resouce_name, :resource_type,
+    and :resource_properties
+
+    You provided: %1
+
+
   # Maps to: NameError
   CHEFNET001: |
     A network error occurred:
@@ -488,6 +500,7 @@ errors:
     We plan to support a range of target operating systems,
     but during this targeted beta we are constraining our efforts
     to Windows and Linux.
+
 
   footer:
     both: |

--- a/lib/chef_apply/action/generate_local_policy.rb
+++ b/lib/chef_apply/action/generate_local_policy.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef_apply/action/base"
+require "chef_apply/error"
+module ChefApply::Action
+  class GenerateLocalPolicy < Base
+    attr_reader :archive_file_location
+    def initialize(config)
+      super(config)
+      @cookbook = config.delete :cookbook
+    end
+
+    def perform_action
+      notify(:generating)
+      installer.run
+      notify(:exporting)
+      exporter.run
+      @archive_file_location = exporter.archive_file_location
+      notify(:success)
+    rescue ChefDK::PolicyfileInstallError => e
+      raise PolicyfileInstallError.new(e)
+    end
+
+    def exporter
+      require "chef-dk/policyfile_services/export_repo"
+      @exporter ||=
+        ChefDK::PolicyfileServices::ExportRepo.new(policyfile: @cookbook.policyfile_lock_path,
+                                                   root_dir: @cookbook.path,
+                                                   export_dir: @cookbook.export_path,
+                                                   archive: true, force: true)
+    end
+
+    def installer
+      require "chef-dk/policyfile_services/install"
+      require "chef-dk/ui"
+      @installer ||=
+        ChefDK::PolicyfileServices::Install.new(ui: ChefDK::UI.null(), root_dir: @cookbook.path)
+    end
+
+  end
+  class PolicyfileInstallError < ChefApply::Error
+    def initialize(cause_err); super("CHEFPOLICY001", cause_err.message); end
+  end
+end

--- a/lib/chef_apply/action/generate_temp_cookbook.rb
+++ b/lib/chef_apply/action/generate_temp_cookbook.rb
@@ -1,0 +1,86 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef_apply/action/base"
+require "chef_apply/temp_cookbook"
+require "chef_apply/error"
+
+module ChefApply::Action
+  class GenerateTempCookbook < Base
+    attr_reader :generated_cookbook
+
+    def self.from_options(opts)
+      if opts.has_key?(:recipe_spec)
+        GenerateCookbookFromRecipe.new(opts)
+      elsif opts.has_key?(:resource_name) &&
+          opts.has_key?(:resource_type) &&
+          opts.has_key?(:resource_properties)
+        GenerateCookbookFromResource.new(opts)
+      else
+        raise MissingOptions.new(opts)
+      end
+    end
+
+    def initialize(options)
+      super(options)
+      @generated_cookbook ||= ChefApply::TempCookbook.new
+    end
+
+    def perform_action
+      notify(:generating)
+      generate
+      notify(:success)
+    end
+
+    def generate
+      raise NotImplemented
+    end
+  end
+
+  class GenerateCookbookFromRecipe < GenerateTempCookbook
+    def generate
+      recipe_specifier = config.delete :recipe_spec
+      repo_paths = config.delete :cookbook_repo_paths
+      ChefApply::Log.debug("Beginning to look for recipe specified as #{recipe_specifier}")
+      if File.file?(recipe_specifier)
+        ChefApply::Log.debug("#{recipe_specifier} is a valid path to a recipe")
+        recipe_path = recipe_specifier
+      else
+        require "chef_apply/recipe_lookup"
+        rl = ChefApply::RecipeLookup.new(repo_paths)
+        cookbook_path_or_name, optional_recipe_name = rl.split(recipe_specifier)
+        cookbook = rl.load_cookbook(cookbook_path_or_name)
+        recipe_path = rl.find_recipe(cookbook, optional_recipe_name)
+      end
+      generated_cookbook.from_existing_recipe(recipe_path)
+    end
+  end
+
+  class GenerateCookbookFromResource < GenerateTempCookbook
+    def generate
+      type = config.delete :resource_type
+      name = config.delete :resource_name
+      props = config.delete :resource_properties
+      ChefApply::Log.debug("Generating cookbook for ad-hoc resource #{type}[#{name}]")
+      generated_cookbook.from_resource(type, name, props)
+    end
+  end
+
+  class MissingOptions < ChefApply::APIError
+    def initialize(*args); super("CHEFAPI001", *args); end
+  end
+end

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -161,9 +161,9 @@ module ChefApply
     end
 
     def install(target_host, reporter)
-      reporter.update(TS.install_chef.verifying)
-      installer = Action::InstallChef.instance_for_target(target_host, check_only: !parsed_options[:install])
       context = TS.install_chef
+      reporter.update(context.verifying)
+      installer = Action::InstallChef.instance_for_target(target_host, check_only: !parsed_options[:install])
       installer.run do |event, data|
         case event
         when :installing

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -1,4 +1,5 @@
 #
+#p
 # Copyright:: Copyright (c) 2018 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -15,35 +16,37 @@
 # limitations under the License.
 #
 require "mixlib/cli"
-require "chef/log"
+
+require "chef_apply/config"
 require "chef-config/config"
 require "chef-config/logger"
 
-require "chef_apply/cli/help"
-require "chef_apply/cli/options"
 require "chef_apply/cli/validation"
-
+require "chef_apply/cli/options"
+require "chef_apply/cli/help"
 require "chef_apply/action/converge_target"
+require "chef_apply/action/generate_local_policy"
+require "chef_apply/action/generate_temp_cookbook"
 require "chef_apply/action/install_chef"
-require "chef_apply/config"
 require "chef_apply/error"
 require "chef_apply/log"
-require "chef_apply/recipe_lookup"
 require "chef_apply/target_host"
 require "chef_apply/target_resolver"
 require "chef_apply/telemeter"
-require "chef_apply/telemeter/sender"
-require "chef_apply/temp_cookbook"
 require "chef_apply/ui/error_printer"
 require "chef_apply/ui/terminal"
-require "chef_apply/version"
 
 module ChefApply
   class CLI
+    attr_reader :temp_cookbook, :archive_file_location, :target_hosts
+
     include Mixlib::CLI
+    # Pulls in the CLI options and flags we have defined for this command.
     include ChefApply::CLI::Options
-    include ChefApply::CLI::Help
+    # Argument validation and parsing behaviors
     include ChefApply::CLI::Validation
+    # Help and version formatting
+    include ChefApply::CLI::Help
 
     RC_OK = 0
     RC_COMMAND_FAILED = 1
@@ -103,26 +106,11 @@ module ChefApply
         show_version
       else
         validate_params(cli_arguments)
-        target_hosts = TargetResolver.new(cli_arguments.shift,
-                                          parsed_options.delete(:protocol),
-                                          parsed_options).targets
-        temp_cookbook, initial_status_msg = generate_temp_cookbook(cli_arguments)
-        local_policy_path = nil
-        UI::Terminal.render_job(TS.generate_policyfile.generating) do |reporter|
-          local_policy_path = create_local_policy(temp_cookbook)
-          reporter.success(TS.generate_policyfile.success)
-        end
-        if target_hosts.length == 1
-          # Note: UX discussed determined that when running with a single target,
-          #       we'll use multiple lines to display status for the target.
-          run_single_target(initial_status_msg, target_hosts[0], local_policy_path)
-        else
-          @multi_target = true
-          # Multi-target will use one line per target.
-          run_multi_target(initial_status_msg, target_hosts, local_policy_path)
-        end
+        target_hosts = resolve_targets(cli_arguments.shift, parsed_options)
+        render_cookbook_setup(cli_arguments)
+        render_converge(target_hosts)
       end
-    rescue OptionParser::InvalidOption => e
+    rescue OptionParser::InvalidOption => e # from parse_options
       # Using nil here is a bit gross but it prevents usage from printing.
       ove = OptionValidationError.new("CHEFVAL010", nil,
                                       e.message.split(":")[1].strip, # only want the flag
@@ -135,109 +123,45 @@ module ChefApply
       temp_cookbook.delete unless temp_cookbook.nil?
     end
 
-    # Accepts a target_host and establishes the connection to that host
-    # while providing visual feedback via the Terminal API.
-    def connect_target(target_host, reporter = nil)
-      connect_message = T.status.connecting(target_host.user)
-      if reporter.nil?
-        UI::Terminal.render_job(connect_message, prefix: "[#{target_host.config[:host]}]") do |rep|
-          do_connect(target_host, rep, :success)
-        end
-      else
-        reporter.update(connect_message)
-        do_connect(target_host, reporter, :update)
-      end
-      target_host
+    def resolve_targets(host_spec, opts)
+      @target_hosts = TargetResolver.new(host_spec,
+                                         opts.delete(:protocol),
+                                         opts).targets
     end
 
-    def run_single_target(initial_status_msg, target_host, local_policy_path)
-      connect_target(target_host)
-      prefix = "[#{target_host.hostname}]"
-      UI::Terminal.render_job(TS.install_chef.verifying, prefix: prefix) do |reporter|
-        install(target_host, reporter)
+    def render_cookbook_setup(arguments)
+      UI::Terminal.render_job(TS.generate_temp_cookbook.generating) do |reporter|
+        @temp_cookbook = generate_temp_cookbook(arguments, reporter)
       end
-      UI::Terminal.render_job(initial_status_msg, prefix: "[#{target_host.hostname}]") do |reporter|
-        converge(reporter, local_policy_path, target_host)
+      UI::Terminal.render_job(TS.generate_temp_cookbook.generating) do |reporter|
+        @archive_file_location = generate_local_policy(reporter)
       end
     end
 
-    def run_multi_target(initial_status_msg, target_hosts, local_policy_path)
-      # Our multi-host UX does not show a line item per action,
-      # but rather a line-item per connection.
+    def render_converge(target_hosts)
       jobs = target_hosts.map do |target_host|
-        # This block will run in its own thread during render.
+        # Each block will run in its own thread during render.
         UI::Terminal::Job.new("[#{target_host.hostname}]", target_host) do |reporter|
           connect_target(target_host, reporter)
-          reporter.update(TS.install_chef.verifying)
           install(target_host, reporter)
-          reporter.update(initial_status_msg)
-          converge(reporter, local_policy_path, target_host)
+          converge(reporter, archive_file_location, target_host)
         end
       end
-      UI::Terminal.render_parallel_jobs(TS.converge.multi_header, jobs)
+      header = TS.converge.header(target_hosts.length, temp_cookbook.descriptor, temp_cookbook.from)
+      UI::Terminal.render_parallel_jobs(header, jobs)
       handle_job_failures(jobs)
     end
 
-    # The user will either specify a single resource on the command line, or a recipe.
-    # We need to parse out those two different situations
-    def generate_temp_cookbook(cli_arguments)
-      temp_cookbook = TempCookbook.new
-      if recipe_strategy?(cli_arguments)
-        recipe_specifier = cli_arguments.shift
-        ChefApply::Log.debug("Beginning to look for recipe specified as #{recipe_specifier}")
-        if File.file?(recipe_specifier)
-          ChefApply::Log.debug("#{recipe_specifier} is a valid path to a recipe")
-          recipe_path = recipe_specifier
-        else
-          rl = RecipeLookup.new(parsed_options[:cookbook_repo_paths])
-          cookbook_path_or_name, optional_recipe_name = rl.split(recipe_specifier)
-          cookbook = rl.load_cookbook(cookbook_path_or_name)
-          recipe_path = rl.find_recipe(cookbook, optional_recipe_name)
-        end
-        temp_cookbook.from_existing_recipe(recipe_path)
-        initial_status_msg = TS.converge.converging_recipe(recipe_specifier)
-      else
-        resource_type = cli_arguments.shift
-        resource_name = cli_arguments.shift
-        temp_cookbook.from_resource(resource_type, resource_name, properties_from_string(cli_arguments))
-        full_rs_name = "#{resource_type}[#{resource_name}]"
-        ChefApply::Log.debug("Converging resource #{full_rs_name} on target")
-        initial_status_msg = TS.converge.converging_resource(full_rs_name)
-      end
-
-      [temp_cookbook, initial_status_msg]
+    # Accepts a target_host and establishes the connection to that host
+    # while providing visual feedback via the Terminal API.
+    def connect_target(target_host, reporter)
+      connect_message = T.status.connecting(target_host.user)
+      reporter.update(connect_message)
+      do_connect(target_host, reporter)
     end
 
-    def recipe_strategy?(cli_arguments)
-      cli_arguments.size == 1
-    end
-
-    def create_local_policy(local_cookbook)
-      require "chef-dk/ui"
-      require "chef-dk/policyfile_services/export_repo"
-      require "chef-dk/policyfile_services/install"
-      policyfile_installer = ChefDK::PolicyfileServices::Install.new(
-        ui: ChefDK::UI.null(),
-        root_dir: local_cookbook.path
-      )
-      begin
-        policyfile_installer.run
-      rescue ChefDK::PolicyfileInstallError => e
-        raise PolicyfileInstallError.new(e)
-      end
-      lock_path = File.join(local_cookbook.path, "Policyfile.lock.json")
-      es = ChefDK::PolicyfileServices::ExportRepo.new(policyfile: lock_path,
-                                                      root_dir: local_cookbook.path,
-                                                      export_dir: File.join(local_cookbook.path, "export"),
-                                                      archive: true,
-                                                      force: true)
-      es.run
-      es.archive_file_location
-    end
-
-    # Runs the InstallChef action and renders UI updates as
-    # the action reports back
     def install(target_host, reporter)
+      reporter.update(TS.install_chef.verifying)
       installer = Action::InstallChef.instance_for_target(target_host, check_only: !parsed_options[:install])
       context = TS.install_chef
       installer.run do |event, data|
@@ -254,39 +178,82 @@ module ChefApply
         when :downloading
           reporter.update(context.downloading)
         when :already_installed
-          meth = @multi_target ? :update : :success
-          reporter.send(meth, context.already_present(target_host.installed_chef_version))
+          reporter.update(context.already_present(target_host.installed_chef_version))
         when :install_complete
-          meth = @multi_target ? :update : :success
           if installer.upgrading?
             message = context.upgrade_success(target_host.installed_chef_version, installer.version_to_install)
           else
             message = context.install_success(installer.version_to_install)
           end
-          reporter.send(meth, message)
+          reporter.update(message)
         else
           handle_message(event, data, reporter)
         end
       end
     end
 
+    # Runs a GenerateCookbook action based on recipe/resource infoprovided
+    # and renders UI updates as the action reports back
+    def generate_temp_cookbook(arguments, reporter)
+      opts = if arguments.length == 1
+               { recipe_spec: arguments.shift,
+                 cookbook_repo_paths: parsed_options[:cookbook_repo_paths] }
+             else
+               { resource_type: arguments.shift,
+                 resource_name: arguments.shift,
+                 resource_properties: properties_from_string(arguments) }
+             end
+      action = ChefApply::Action::GenerateTempCookbook.from_options(opts)
+      action.run do |event, data|
+        case event
+        when :generating
+          reporter.update(TS.generate_temp_cookbook.generating)
+        when :success
+          reporter.success(TS.generate_temp_cookbook.success)
+        else
+          handle_message(event, data, reporter)
+        end
+      end
+      action.generated_cookbook
+    end
+
+    # Runs the GenerateLocalPolicy action and renders UI updates
+    # as the action reports back
+    def generate_local_policy(reporter)
+      action = Action::GenerateLocalPolicy.new(cookbook: temp_cookbook)
+      action.run do |event, data|
+        case event
+        when :generating
+          reporter.update(TS.generate_local_policy.generating)
+        when :exporting
+          reporter.update(TS.generate_local_policy.exporting)
+        when :success
+          reporter.success(TS.generate_local_policy.success)
+        else
+          handle_message(event, data, reporter)
+        end
+      end
+      action.archive_file_location
+    end
+
     # Runs the Converge action and renders UI updates as
     # the action reports back
     def converge(reporter, local_policy_path, target_host)
+      reporter.update(TS.converge.converging(temp_cookbook.descriptor))
       converge_args = { local_policy_path: local_policy_path, target_host: target_host }
       converger = Action::ConvergeTarget.new(converge_args)
       converger.run do |event, data|
         case event
         when :success
-          reporter.success(TS.converge.success)
+          reporter.success(TS.converge.success(temp_cookbook.descriptor))
         when :converge_error
-          reporter.error(TS.converge.failure)
+          reporter.error(TS.converge.failure(temp_cookbook.descriptor))
         when :creating_remote_policy
           reporter.update(TS.converge.creating_remote_policy)
         when :uploading_trusted_certs
           reporter.update(TS.converge.uploading_trusted_certs)
         when :running_chef
-          reporter.update(TS.converge.running_chef)
+          reporter.update(TS.converge.converging(temp_cookbook.descriptor))
         when :reboot
           reporter.success(TS.converge.reboot)
         else
@@ -311,13 +278,16 @@ module ChefApply
 
     # When running multiple jobs, exceptions are captured to the
     # job to avoid interrupting other jobs in process.  This function
-    # collects them and raises a MultiJobFailure if failure has occurred;
-    # we do *not* differentiate between one failed jobs and multiple failed jobs
-    # - if you're in the 'multi-job' path (eg, multiple targets) we handle
-    # all errors the same to provide a consistent UX when running with mulitiple targets.
+    # collects them and raises directly (in the case of just one job in the list)
+    # or raises a MultiJobFailure (when more than one job was being run)
     def handle_job_failures(jobs)
       failed_jobs = jobs.select { |j| !j.exception.nil? }
       return if failed_jobs.empty?
+      if jobs.length == 1
+        # Don't provide a bad UX by showing a 'one or more jobs has failed'
+        # message when there was only one job.
+        raise jobs.first.exception
+      end
       raise ChefApply::MultiJobFailure.new(failed_jobs)
     end
 
@@ -333,27 +303,14 @@ module ChefApply
       UI::ErrorPrinter.write_backtrace(e, @argv)
     end
 
-    def do_connect(target_host, reporter, update_method)
+    def do_connect(target_host, reporter)
       target_host.connect!
-      reporter.send(update_method, T.status.connected)
+      reporter.update(T.status.connected)
     rescue StandardError => e
       message = ChefApply::UI::ErrorPrinter.error_summary(e)
       reporter.error(message)
       raise
     end
 
-    class OptionValidationError < ChefApply::ErrorNoLogs
-      attr_reader :command
-      def initialize(id, calling_command, *args)
-        super(id, *args)
-        # TODO - this is getting cumbersome - move them to constructor options hash in base
-        @decorate = false
-        @command = calling_command
-      end
-    end
-
-    class PolicyfileInstallError < ChefApply::Error
-      def initialize(cause_err); super("CHEFPOLICY001", cause_err.message); end
-    end
   end
 end

--- a/lib/chef_apply/cli/validation.rb
+++ b/lib/chef_apply/cli/validation.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+require "chef_apply/error"
+
 module ChefApply
   class CLI
     module Validation
@@ -81,7 +83,17 @@ module ChefApply
           value
         end
       end
+    end
 
+    class OptionValidationError < ChefApply::ErrorNoLogs
+      attr_reader :command
+      def initialize(id, calling_command, *args)
+        super(id, *args)
+        # TODO - this is getting cumbersome - move them to constructor options hash in base
+        @decorate = false
+        @command = calling_command
+      end
     end
   end
+
 end

--- a/lib/chef_apply/error.rb
+++ b/lib/chef_apply/error.rb
@@ -53,13 +53,18 @@ module ChefApply
     end
   end
 
-  class MultiJobFailure < ChefApply::ErrorNoLogs
+  class MultiJobFailure < ErrorNoLogs
     attr_reader :jobs
     def initialize(jobs)
       super("CHEFMULTI001")
       @jobs = jobs
       @decorate = false
     end
+  end
+
+  # Provide a base type for internal usage errors that should not leak out
+  # but may anyway.
+  class APIError < Error
   end
 
   # Provides mappings of common errors that we don't explicitly
@@ -104,5 +109,4 @@ module ChefApply
       require "openssl"
     end
   end
-
 end

--- a/spec/unit/action/generate_local_policy_spec.rb
+++ b/spec/unit/action/generate_local_policy_spec.rb
@@ -1,0 +1,114 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require "spec_helper"
+require "chef_apply/action/generate_local_policy"
+require "chef-dk/policyfile_services/install"
+require "chef-dk/ui"
+require "chef-dk/policyfile_services/export_repo"
+
+RSpec.describe ChefApply::Action::GenerateLocalPolicy do
+  subject { ChefApply::Action::GenerateLocalPolicy.new(cookbook: cookbook) }
+  let(:cookbook) do
+    double("TempCookbook",
+           path: "/my/temp/cookbook",
+           export_path: "/my/temp/cookbook/export",
+           policyfile_lock_path: "/my/temp/cookbook/policyfile.lock")
+  end
+
+  let(:installer_double) do
+    instance_double(ChefDK::PolicyfileServices::Install, run: :ok)
+  end
+
+  let(:exporter_double) do
+    instance_double(ChefDK::PolicyfileServices::ExportRepo,
+                    archive_file_location: "/path/to/export",
+                    run: :ok)
+  end
+
+  before do
+    allow(subject).to receive(:notify)
+  end
+
+  describe "#perform_action" do
+    context "in the normal case" do
+      it "exports the policy notifying caller of progress, setting archive_file_location" do
+        expect(subject).to receive(:notify).ordered.with(:generating)
+        expect(subject).to receive(:installer).ordered.and_return installer_double
+        expect(installer_double).to receive(:run).ordered
+        expect(subject).to receive(:notify).ordered.with(:exporting)
+        expect(subject).to receive(:exporter).ordered.and_return exporter_double
+        expect(exporter_double).to receive(:run).ordered
+        expect(subject).to receive(:exporter).ordered.and_return exporter_double
+        expect(subject).to receive(:notify).ordered.with(:success)
+        subject.perform_action
+        expect(subject.archive_file_location).to eq("/path/to/export")
+      end
+    end
+
+    context "when PolicyfileServices raises an error" do
+      it "reraises as PolicyfileInstallError" do
+        expect(subject).to receive(:installer).and_return installer_double
+        expect(installer_double).to receive(:run).and_raise(ChefDK::PolicyfileInstallError.new("", nil))
+        expect { subject.perform_action }.to raise_error(ChefApply::Action::PolicyfileInstallError)
+      end
+    end
+
+    context "when the path name is too long" do
+      let(:name) { "THIS_IS_A_REALLY_LONG_STRING111111111111111111111111111111111111111111111111111111" }
+
+      # There is an issue with policyfile generation where, if we have a cookbook with too long
+      # of a name or directory name the policyfile will not generate. This is because the tar
+      # library that ChefDK uses comes from the Rubygems package and is meant for packaging
+      # gems up, so it can impose a 100 character limit. We attempt to solve this by ensuring
+      # that the paths/names we generate with `TempCookbook` are short.
+      #
+      # This is here for documentation
+      # 2018-05-18 mp addendum: this cna take upwards of 15s to run on ci nodes, pending
+      # for now since it's not testing any Chef Apply functionality.
+      xit "fails to create when there is a long path name" do
+        err = ChefDK::PolicyfileExportRepoError
+        expect { subject.perform_action }.to raise_error(err) do |e|
+          expect(e.cause.class).to eq(Gem::Package::TooLongFileName)
+          expect(e.cause.message).to match(/should be 100 or less/)
+        end
+      end
+    end
+  end
+
+  describe "#exporter" do
+
+    it "returns a correctly constructed ExportRepo" do
+      expect(ChefDK::PolicyfileServices::ExportRepo).to receive(:new)
+        .with(policyfile: cookbook.policyfile_lock_path,
+              root_dir: cookbook.path,
+              export_dir:  cookbook.export_path,
+              archive: true, force: true)
+        .and_return exporter_double
+      expect(subject.exporter).to eq exporter_double
+    end
+  end
+
+  describe "#installer" do
+    it "returns a correctly constructed Install service" do
+      expect(ChefDK::PolicyfileServices::Install).to receive(:new)
+        .with(ui: ChefDK::UI, root_dir: cookbook.path)
+        .and_return(installer_double)
+      expect(subject.installer).to eq installer_double
+    end
+  end
+
+end

--- a/spec/unit/action/generate_temp_cookbook_spec.rb
+++ b/spec/unit/action/generate_temp_cookbook_spec.rb
@@ -1,0 +1,75 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef_apply/action/generate_temp_cookbook"
+
+RSpec.describe ChefApply::Action::GenerateTempCookbook do
+  let(:options) { {} }
+  subject { ChefApply::Action::GenerateTempCookbook }
+
+  describe ".from_options" do
+    context "when given options for a recipe" do
+      let(:options) { { recipe_spec: "some::recipe" } }
+      it "returns a GenerateCookbookFromRecipe action" do
+        expect(subject.from_options(options)).to be_a(ChefApply::Action::GenerateCookbookFromRecipe)
+      end
+    end
+
+    context "when given options for a resource" do
+      let(:resource_properties) { {} }
+      let(:options) do
+        { resource_name: "user1", resource_type: "user",
+          resource_properties: resource_properties } end
+
+      it "returns a GenerateCookbookFromResource action" do
+        expect(subject.from_options(options)).to be_a ChefApply::Action::GenerateCookbookFromResource
+      end
+    end
+
+    context "when not given sufficient options for either" do
+      let(:options) { {} }
+      it "raises MissingOptions" do
+        expect { subject.from_options(options) }.to raise_error ChefApply::Action::MissingOptions
+      end
+    end
+
+  end
+
+  describe "#perform_action" do
+    subject { ChefApply::Action::GenerateTempCookbook.new( {} ) }
+    it "generates a cookbook, notifies caller, and makes the cookbook available" do
+
+      expect(subject).to receive(:notify).ordered.with(:generating)
+      expect(subject).to receive(:generate)
+      expect(subject).to receive(:notify).ordered.with(:success)
+      subject.perform_action
+      expect(subject.generated_cookbook).to_not be nil
+    end
+
+  end
+
+end
+
+RSpec.describe ChefApply::Action::GenerateCookbookFromRecipe do
+  describe "#generate" do
+  end
+end
+
+RSpec.describe ChefApply::Action::GenerateCookbookFromResource do
+  describe "#generate" do
+  end
+end

--- a/spec/unit/cli/validation_spec.rb
+++ b/spec/unit/cli/validation_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 require "chef_apply/error"
+require "chef_apply/cli/validation"
+
 RSpec.describe ChefApply::CLI::Validation do
   class Validator
     include ChefApply::CLI::Validation

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -21,17 +21,16 @@ require "chef_apply/error"
 require "chef_apply/telemeter"
 require "chef_apply/telemeter/sender"
 require "chef_apply/ui/terminal"
+require "chef_apply/action/generate_temp_cookbook"
 
 require "chef-dk/ui"
 require "chef-dk/policyfile_services/export_repo"
 require "chef-dk/policyfile_services/install"
 
 RSpec.describe ChefApply::CLI do
+  subject { ChefApply::CLI.new(argv) }
   let(:argv) { [] }
-
-  subject(:cli) do
-    ChefApply::CLI.new(argv)
-  end
+  # TODO why isn't this mocked?
   let(:telemetry) { ChefApply::Telemeter.instance }
 
   before do
@@ -135,106 +134,23 @@ RSpec.describe ChefApply::CLI do
       end
     end
 
-    context "when argv is not empty and no flags are provided" do
-      let(:argv) { %w{host resource name} }
-      let(:mock_cb) { instance_double("TempCookbook", delete: nil) }
-      let(:archive) { "archive.tgz" }
-      let(:reporter) { double("reporter") }
-      before(:each) do
-        allow(subject).to receive(:validate_params)
-        allow(subject).to receive(:generate_temp_cookbook).and_return([mock_cb, "test"])
-        allow(subject).to receive(:create_local_policy).and_return(archive)
-        allow(subject).to receive(:run_single_target)
-        allow(subject).to receive(:run_multi_target)
-        allow_any_instance_of(ChefApply::TargetResolver).to receive(:targets).and_return(["host"])
+    context "when arguments are provided" do
+      let(:argv) { ["hostname", "resourcetype", "resourcename", "someproperty=true"] }
+      let(:target_hosts) { [double("TargetHost")] }
+      before do
+        # parse_options sets `cli_argument` - because we stub out parse_options,
+        # later calls that rely on cli_arguments will fail without this.
+        allow(subject).to receive(:cli_arguments).and_return argv
       end
 
-      it "validates parameters" do
-        expect(subject).to receive(:validate_params).with(argv)
-        subject.perform_run
-      end
-
-      it "performs the steps required to create the local policy" do
-        expect(subject).to receive(:generate_temp_cookbook).ordered.and_return([mock_cb, "test"])
-        generating = ChefApply::Text.status.generate_policyfile.generating
-        expect(ChefApply::UI::Terminal).to receive(:render_job).with(generating).and_yield(reporter)
-        expect(subject).to receive(:create_local_policy).with(mock_cb).ordered
-        success = ChefApply::Text.status.generate_policyfile.success
-        expect(reporter).to receive(:success).with(success)
-        subject.perform_run
-      end
-
-      context "and there is a single target host" do
-        before do
-          allow_any_instance_of(ChefApply::TargetResolver).to receive(:targets).and_return(["host"])
-        end
-
-        it "calls run_single_target" do
-          expect(subject).to receive(:run_single_target).with("test", "host", archive)
+      context "and they are valid" do
+        it "creates the cookbook locally and converges it" do
+          expect(subject).to receive(:parse_options)
+          expect(subject).to receive(:validate_params)
+          expect(subject).to receive(:resolve_targets).and_return target_hosts
+          expect(subject).to receive(:render_cookbook_setup)
+          expect(subject).to receive(:render_converge).with(target_hosts)
           subject.perform_run
-        end
-      end
-
-      context "and there are multiple target hosts" do
-        before do
-          allow_any_instance_of(ChefApply::TargetResolver).to receive(:targets).and_return(%w{host host2})
-        end
-
-        it "calls run_multi_target" do
-          expect(subject).to receive(:run_multi_target).with("test", %w{host host2}, archive)
-          expect(mock_cb).to receive(:delete)
-          subject.perform_run
-        end
-      end
-    end
-  end
-
-  describe "#validate_params" do
-    OptionValidationError = ChefApply::CLI::OptionValidationError
-    it "raises an error if not enough params are specified" do
-      params = [
-        [],
-        %w{one}
-      ]
-      params.each do |p|
-        expect { subject.validate_params(p) }.to raise_error(OptionValidationError) do |e|
-          e.id == "CHEFVAL002"
-        end
-      end
-    end
-
-    it "succeeds if the second command is a valid file path" do
-      params = %w{target /some/path}
-      expect(File).to receive(:exist?).with("/some/path").and_return true
-      expect { subject.validate_params(params) }.to_not raise_error
-    end
-
-    it "succeeds if the second argument looks like a cookbook name" do
-      params = [
-        %w{target cb},
-        %w{target cb::recipe}
-      ]
-      params.each do |p|
-        expect { subject.validate_params(p) }.to_not raise_error
-      end
-    end
-
-    it "raises an error if the second argument is neither a valid path or a valid cookbook name" do
-      params = %w{target weird%name}
-      expect { subject.validate_params(params) }.to raise_error(OptionValidationError) do |e|
-        e.id == "CHEFVAL004"
-      end
-    end
-
-    it "raises an error if properties are not specified as key value pairs" do
-      params = [
-        %w{one two three four},
-        %w{one two three four=value five six=value},
-        %w{one two three non.word=value},
-      ]
-      params.each do |p|
-        expect { subject.validate_params(p) }.to raise_error(OptionValidationError) do |e|
-          e.id == "CHEFVAL003"
         end
       end
     end
@@ -242,174 +158,185 @@ RSpec.describe ChefApply::CLI do
 
   describe "#connect_target" do
     let(:host) { double("TargetHost", config: {}, user: "root" ) }
-    context "when simulating the multi-host path" do
-      let(:reporter) { double("reporter", update: :ok, success: :ok) }
-      it "invokes do_connect with correct options" do
-        expect(subject).to receive(:do_connect).
-          with(host, reporter, :update)
-        subject.connect_target(host, reporter)
-      end
-    end
-
-    context "when simulating the single-host path" do
-      it "invokes do_connect with correct options" do
-        expect(subject).to receive(:do_connect).
-          with(host, anything(), :success)
-        subject.connect_target(host)
-      end
+    let(:reporter) { double("reporter", update: :ok, success: :ok) }
+    it "invokes do_connect with correct options" do
+      expect(subject).to receive(:do_connect).
+        with(host, reporter)
+      subject.connect_target(host, reporter)
     end
   end
 
   describe "#generate_temp_cookbook" do
-    let(:tc) { instance_double(ChefApply::TempCookbook) }
+    let(:temp_cookbook) { double("TempCookbook") }
+    let(:action) { double("generator", generated_cookbook: temp_cookbook) }
+
+    context "when a resource is provided" do
+      it "gets an action via GenerateTemporaryCookbook.from_options and executes it " do
+        expect(ChefApply::Action::GenerateTempCookbook)
+          .to receive(:from_options)
+          .with(resource_type: "user",
+                resource_name: "test", resource_properties: {})
+          .and_return(action)
+        expect(action).to receive(:run)
+        expect(subject.generate_temp_cookbook(%w{user test}, nil)).to eq temp_cookbook
+      end
+    end
+
+    context "when a recipe specifier is provided" do
+      it "gets an action via GenerateTemporaryCookbook.from_options and executes it" do
+        expect(ChefApply::Action::GenerateTempCookbook)
+          .to receive(:from_options)
+          .with(recipe_spec: "mycookbook::default")
+          .and_return(action)
+        expect(action).to receive(:run)
+        subject.generate_temp_cookbook(["mycookbook::default"], nil)
+      end
+    end
+
+    context "when generator posts event:" do
+      let(:reporter) { double("reporter") }
+      before do
+        expect(ChefApply::Action::GenerateTempCookbook)
+          .to receive(:from_options)
+          .and_return(action)
+        allow(action).to receive(:run) { |&block| block.call(event, event_args) }
+      end
+
+      context ":generating" do
+        let(:event) { :generating }
+        let(:event_args) { nil }
+        it "updates message text via reporter" do
+          expected_text = ChefApply::CLI::TS.generate_temp_cookbook.generating
+          expect(reporter).to receive(:update).with(expected_text)
+          subject.generate_temp_cookbook(%w{user jimbo}, reporter)
+        end
+      end
+
+      context ":success" do
+        let(:event) { :success }
+        let(:event_args) { [ temp_cookbook ] }
+        it "indicates success via reporter and returns the cookbook" do
+          expected_text = ChefApply::CLI::TS.generate_temp_cookbook.success
+          expect(reporter).to receive(:success).with(expected_text)
+          expect(subject.generate_temp_cookbook(%w{user jimbo}, reporter))
+            .to eq temp_cookbook
+        end
+      end
+    end
+  end
+
+  describe "#generate_local_policy" do
+    let(:reporter) { double("reporter") }
+    let(:action) { double("GenerateLocalPolicy") }
+    let(:temp_cookbook) { instance_double("TempCookbook") }
+    let(:archive_file_location) { "/temp/archive.gz" }
 
     before do
-      expect(ChefApply::TempCookbook).to receive(:new).and_return(tc)
+      allow(subject).to receive(:temp_cookbook).and_return temp_cookbook
+      allow(action).to receive(:archive_file_location).and_return archive_file_location
+    end
+    it "creates a GenerateLocalPolicy action and executes it" do
+      expect(ChefApply::Action::GenerateLocalPolicy).to receive(:new)
+        .with(cookbook: temp_cookbook)
+        .and_return(action)
+      expect(action).to receive(:run)
+      subject.generate_local_policy(reporter)
     end
 
-    context "when trying to converge a recipe" do
-      let(:cli_arguments) { [p] }
-      let(:recipe_lookup) { instance_double(ChefApply::RecipeLookup) }
-      let(:status_msg) { ChefApply::Text.status.converge.converging_recipe(p) }
-      let(:cookbook) { double("cookbook") }
-      let(:recipe_path) { "/recipe/path" }
+    context "when generator posts an event:" do
+      before do
+        expect(ChefApply::Action::GenerateLocalPolicy).to receive(:new)
+          .with(cookbook: temp_cookbook)
+          .and_return(action)
+        allow(action).to receive(:run) { |&block| block.call(event, event_args) }
+      end
 
-      context "as a path" do
-        let(:p) { recipe_path }
-        it "returns the recipe path" do
-          expect(File).to receive(:file?).with(p).and_return true
-          expect(tc).to receive(:from_existing_recipe).with(recipe_path)
-          actual1, actual2 = subject.generate_temp_cookbook(cli_arguments)
-          expect(actual1).to eq(tc)
-          expect(actual2).to eq(status_msg)
+      context ":generating" do
+        let(:event) { :generating }
+        let(:event_args) { nil }
+        let(:expected_msg) { ChefApply::CLI::TS.generate_local_policy.generating }
+        it "updates message text correctly via reporter" do
+          expect(reporter).to receive(:update).with(expected_msg)
+          subject.generate_local_policy(reporter)
+        end
+
+      end
+
+      context ":exporting" do
+        let(:event) { :exporting }
+        let(:event_args) { nil }
+        let(:expected_msg) { ChefApply::CLI::TS.generate_local_policy.exporting }
+        it "updates message text correctly via reporter" do
+          expect(reporter).to receive(:update).with(expected_msg)
+          subject.generate_local_policy(reporter)
         end
       end
 
-      context "as a cookbook name" do
-        let(:p) { "cb_name" }
-        it "returns the recipe path" do
-          expect(File).to receive(:file?).with(p).and_return false
-          expect(ChefApply::RecipeLookup).to receive(:new).and_return(recipe_lookup)
-          expect(recipe_lookup).to receive(:split).with(p).and_return([p])
-          expect(recipe_lookup).to receive(:load_cookbook).with(p).and_return(cookbook)
-          expect(recipe_lookup).to receive(:find_recipe).with(cookbook, nil).and_return(recipe_path)
-          expect(tc).to receive(:from_existing_recipe).with(recipe_path)
-          actual1, actual2 = subject.generate_temp_cookbook(cli_arguments)
-          expect(actual1).to eq(tc)
-          expect(actual2).to eq(status_msg)
+      context ":success" do
+        let(:event) { :success }
+        let(:expected_msg) { ChefApply::CLI::TS.generate_local_policy.success }
+        let(:event_args) { [archive_file_location] }
+        it "indicates success via reporter and returns the archive file location" do
+          expect(reporter).to receive(:success).with(expected_msg)
+          expect(subject.generate_local_policy(reporter)).to eq archive_file_location
         end
-      end
 
-      context "as a cookbook and recipe name" do
-        let(:cookbook_name) { "cb_name" }
-        let(:recipe_name) { "recipe_name" }
-        let(:p) { cookbook_name + "::" + recipe_name }
-        it "returns the recipe path" do
-          expect(File).to receive(:file?).with(p).and_return false
-          expect(ChefApply::RecipeLookup).to receive(:new).and_return(recipe_lookup)
-          expect(recipe_lookup).to receive(:split).with(p).and_return([cookbook_name, recipe_name])
-          expect(recipe_lookup).to receive(:load_cookbook).with(cookbook_name).and_return(cookbook)
-          expect(recipe_lookup).to receive(:find_recipe).with(cookbook, recipe_name).and_return(recipe_path)
-          expect(tc).to receive(:from_existing_recipe).with(recipe_path)
-          actual1, actual2 = subject.generate_temp_cookbook(cli_arguments)
-          expect(actual1).to eq(tc)
-          expect(actual2).to eq(status_msg)
-        end
       end
-
     end
 
-    context "when trying to converge a resource" do
-      let(:cli_arguments) { %w{directory foo prop1=val1 prop2=val2} }
-      it "returns the resource information" do
-        expect(tc).to receive(:from_resource).with("directory", "foo", { "prop1" => "val1", "prop2" => "val2" })
-        actual1, actual2 = subject.generate_temp_cookbook(cli_arguments)
-        expect(actual1).to eq(tc)
-        msg = ChefApply::Text.status.converge.converging_resource("directory[foo]")
-        expect(actual2).to eq(msg)
-      end
-    end
   end
 
-  describe "#run_single_target" do
-    let(:installer) { instance_double(ChefApply::Action::InstallChef::Linux) }
-    let(:converger) { instance_double(ChefApply::Action::ConvergeTarget) }
+  describe "#render_cookbook_setup" do
     let(:reporter) { instance_double(ChefApply::StatusReporter) }
-    let(:host1) { ChefApply::TargetHost.new("ssh://host1") }
-    it "connects, installs chef on and converges the target" do
-      expect(subject).to receive(:connect_target).with(host1)
-      expect(subject).to receive(:install).with(host1, anything())
-      expect(subject).to receive(:converge)
-      subject.run_single_target("", host1, {})
+    let(:temp_cookbook) { double(ChefApply::TempCookbook) }
+    let(:archive_file_location) { "/path/to/archive" }
+    let(:args) { [] }
+    before do
+      allow(ChefApply::UI::Terminal).to receive(:render_job).and_yield(reporter)
     end
+
+    it "generates the cookbook and local policy" do
+      expect(subject).to receive(:generate_temp_cookbook)
+        .with(args, reporter).and_return temp_cookbook
+      expect(subject).to receive(:generate_local_policy)
+        .with(reporter).and_return archive_file_location
+      subject.render_cookbook_setup(args)
+    end
+
   end
 
-  describe "#run_multi_target" do
+  describe "#render_converge" do
+
     let(:reporter) { instance_double(ChefApply::StatusReporter) }
     let(:host1) { ChefApply::TargetHost.new("ssh://host1") }
     let(:host2) { ChefApply::TargetHost.new("ssh://host2") }
-    it "connects, installs chef on and converges the targets" do
-      expect(subject).to receive(:connect_target).with(host1, anything())
-      expect(subject).to receive(:connect_target).with(host2, anything())
-      expect(subject).to receive(:install).with(host1, anything())
-      expect(subject).to receive(:install).with(host2, anything())
-      expect(subject).to receive(:converge).exactly(2).times
-      subject.run_multi_target("", [host1, host2], {})
-    end
-  end
+    let(:cookbook_type) { :resource } # || :recipe
+    let(:temp_cookbook) do
+      instance_double(ChefApply::TempCookbook,
+                                               type: cookbook_type,
+                                               name: "a cookbook") end
+    let(:converge_top_status_message) { "converging" }
+    let(:archive_file_location) { "/path/to/archive" }
 
-  describe "#create_local_policy" do
-    let(:name) { "1" }
-    let(:cb) do
-      d = Dir.mktmpdir(name)
-      File.open(File.join(d, "metadata.rb"), "w+") do |f|
-        f << "name \"#{name}\""
-      end
-      File.open(File.join(d, "Policyfile.rb"), "w+") do |f|
-        f << "name \"#{name}_policy\"\n"
-        f << "default_source :supermarket\n"
-        f << "run_list \"#{name}::default\"\n"
-        f << "cookbook \"#{name}\", path: \".\"\n"
-      end
-      FileUtils.mkdir(File.join(d, "recipes"))
-      File.open(File.join(d, "recipes", "default.rb"), "w+") do |f|
-        f << SecureRandom.uuid
-      end
-      File.new(d)
-    end
-
-    after do
-      FileUtils.remove_entry cb
-    end
-
-    context "when PolicyfileServices raises an error" do
-      let(:installer) { instance_double(ChefDK::PolicyfileServices::Install) }
-      it "reraises as PolicyfileInstallError" do
-        expect(ChefDK::PolicyfileServices::Install).to receive(:new).and_return(installer)
-        expect(installer).to receive(:run).and_raise(ChefDK::PolicyfileInstallError.new("", nil))
-        expect { subject.create_local_policy(cb) }.to raise_error(ChefApply::CLI::PolicyfileInstallError)
+    before do
+      allow(subject).to receive(:temp_cookbook).and_return temp_cookbook
+      allow(subject).to receive(:archive_file_location).and_return archive_file_location
+      allow(subject).to receive(:converge_top_status_message).and_return converge_top_status_message
+      allow(ChefApply::UI::Terminal).to receive(:render_parallel_jobs) do |_header, jobs|
+        jobs.each { |j| j.run(reporter) }
       end
     end
 
-    context "when the path name is too long" do
-      let(:name) { "THIS_IS_A_REALLY_LONG_STRING111111111111111111111111111111111111111111111111111111" }
-
-      # There is an issue with policyfile generation where, if we have a cookbook with too long
-      # of a name or directory name the policyfile will not generate. This is because the tar
-      # library that ChefDK uses comes from the Rubygems package and is meant for packaging
-      # gems up, so it can impose a 100 character limit. We attempt to solve this by ensuring
-      # that the paths/names we generate with `TempCookbook` are short.
-      #
-      # This is here for documentation
-      # 2018-05-18 mp addendum: this cna take upwards of 15s to run on ci nodes, pending
-      # for now since it's not testing any Chef Apply functionality.
-      xit "fails to create when there is a long path name" do
-        err = ChefDK::PolicyfileExportRepoError
-        expect { subject.create_local_policy(cb) }.to raise_error(err) do |e|
-          expect(e.cause.class).to eq(Gem::Package::TooLongFileName)
-          expect(e.cause.message).to match(/should be 100 or less/)
-        end
+    let(:target_hosts) { [host1, host2] }
+    it "connects, installs chef, and converges for each target" do
+      target_hosts.each do |host|
+        expect(subject).to receive(:connect_target).with(host, reporter)
+        expect(reporter).to receive(:update).with(ChefApply::CLI::TS.install_chef.verifying)
+        expect(subject).to receive(:install).with(host, reporter)
+        expect(reporter).to receive(:update).with(converge_top_status_message)
+        expect(subject).to receive(:converge).with(reporter, archive_file_location, host)
       end
+      subject.render_converge(target_hosts)
     end
   end
 end

--- a/spec/unit/temp_cookbook_spec.rb
+++ b/spec/unit/temp_cookbook_spec.rb
@@ -161,13 +161,13 @@ RSpec.describe ChefApply::TempCookbook do
     end
   end
 
-  describe "#create_resource" do
+  describe "#create_resource_definition" do
     let(:r1) { "directory" }
     let(:r2) { "/tmp" }
     let(:props) { nil }
     context "when no properties are provided" do
       it "it creates a simple resource" do
-        expect(tc.create_resource(r1, r2, [])).to eq("directory '/tmp'\n")
+        expect(tc.create_resource_definition(r1, r2, [])).to eq("directory '/tmp'\n")
       end
     end
 
@@ -192,7 +192,7 @@ RSpec.describe ChefApply::TempCookbook do
             key_with_underscore 'value'
           end
         EXPECTED_RESOURCE
-        expect(tc.create_resource(r1, r2, props)).to eq(expected)
+        expect(tc.create_resource_definition(r1, r2, props)).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
For review after #12 merges. 

In order to keep the UI logic separate from functional behaviors,
this change moves generation and export of cookbook+policy out of
'cli.rb' and into two new actions GenerateTempCookbook and
GenerateLocalPolicy.

It updates the usage to follow the patterns used for other actions
pulled in by ChefApply::CLI.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
