### PR TITLE
[SHACK-187] housekeeping:  move text and error classes into their own files

### DIFF
--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -263,13 +263,14 @@ module ChefApply
     end
 
     def handle_perform_error(e)
+      require "chef_apply/errors/standard_error_resolver"
       id = e.respond_to?(:id) ? e.id : e.class.to_s
       # TODO: This is currently sending host information for certain ssh errors
       #       post release we need to scrub this data. For now I'm redacting the
       #       whole message.
       # message = e.respond_to?(:message) ? e.message : e.to_s
       Telemeter.capture(:error, exception: { id: id, message: "redacted" })
-      wrapper = ChefApply::StandardErrorResolver.wrap_exception(e)
+      wrapper = ChefApply::Errors::StandardErrorResolver.wrap_exception(e)
       capture_exception_backtrace(wrapper)
       # Now that our housekeeping is done, allow user-facing handling/formatting
       # in `run` to execute by re-raising

--- a/lib/chef_apply/error.rb
+++ b/lib/chef_apply/error.rb
@@ -66,47 +66,5 @@ module ChefApply
   # but may anyway.
   class APIError < Error
   end
-
-  # Provides mappings of common errors that we don't explicitly
-  # handle, but can offer expanded help text around.
-  class StandardErrorResolver
-
-    def self.resolve_exception(exception)
-      deps
-      show_log = true
-      show_stack = true
-      case exception
-      when OpenSSL::SSL::SSLError
-        if exception.message =~ /SSL.*verify failed.*/
-          id = "CHEFNET002"
-          show_log = false
-          show_stack = false
-        end
-      when SocketError then id = "CHEFNET001"; show_log = false; show_stack = false
-      end
-      if id.nil?
-        exception
-      else
-        e = ChefApply::Error.new(id, exception.message)
-        e.show_log = show_log
-        e.show_stack = show_stack
-        e
-      end
-    end
-
-    def self.wrap_exception(original, target_host = nil)
-      resolved_exception = resolve_exception(original)
-      WrappedError.new(resolved_exception, target_host)
-    end
-
-    def self.unwrap_exception(wrapper)
-      resolve_exception(wrapper.contained_exception)
-    end
-
-    def self.deps
-      # Avoid loading additional includes until they're needed
-      require "socket"
-      require "openssl"
-    end
-  end
 end
+

--- a/lib/chef_apply/error.rb
+++ b/lib/chef_apply/error.rb
@@ -67,4 +67,3 @@ module ChefApply
   class APIError < Error
   end
 end
-

--- a/lib/chef_apply/errors/standard_error_resolver.rb
+++ b/lib/chef_apply/errors/standard_error_resolver.rb
@@ -1,0 +1,45 @@
+module ChefApply
+  module Errors
+    # Provides mappings of common errors that we don't explicitly
+    # handle, but can offer expanded help text around.
+    class StandardErrorResolver
+      def self.resolve_exception(exception)
+        deps
+        show_log = true
+        show_stack = true
+        case exception
+        when OpenSSL::SSL::SSLError
+          if exception.message =~ /SSL.*verify failed.*/
+            id = "CHEFNET002"
+            show_log = false
+            show_stack = false
+          end
+        when SocketError then id = "CHEFNET001"; show_log = false; show_stack = false
+        end
+        if id.nil?
+          exception
+        else
+          e = ChefApply::Error.new(id, exception.message)
+          e.show_log = show_log
+          e.show_stack = show_stack
+          e
+        end
+      end
+
+      def self.wrap_exception(original, target_host = nil)
+        resolved_exception = resolve_exception(original)
+        WrappedError.new(resolved_exception, target_host)
+      end
+
+      def self.unwrap_exception(wrapper)
+        resolve_exception(wrapper.contained_exception)
+      end
+
+      def self.deps
+        # Avoid loading additional includes until they're needed
+        require "socket"
+        require "openssl"
+      end
+    end
+  end
+end

--- a/lib/chef_apply/text.rb
+++ b/lib/chef_apply/text.rb
@@ -16,85 +16,30 @@
 #
 
 require "r18n-desktop"
+require "chef_apply/text/text_wrapper"
 
 # A very thin wrapper around R18n, the idea being that we're likely to replace r18n
 # down the road and don't want to have to change all of our commands.
 module ChefApply
-  class Text
-    R18n.from_env(File.join(File.dirname(__FILE__), "../..", "i18n/"))
-    R18n.extension_places << R18n::Loader::YAML.new(File.join(File.dirname(__FILE__), "../..", "i18n/errors/"))
-    t = R18n.get.t
-    t.translation_keys.each do |k|
-      k = k.to_sym
-      define_singleton_method k do |*args|
-        TextWrapper.new(t.send(k, *args))
-      end
+  module Text
+    def self._translation_path
+      @translation_path ||= File.join(File.dirname(__FILE__), "..", "..", "i18n")
     end
-  end
 
-  # Our text spinner class really doesn't like handling the TranslatedString or Untranslated classes returned
-  # by the R18n library. So instead we return these TextWrapper instances which have dynamically defined methods
-  # corresponding to the known structure of the R18n text file. Most importantly, if a user has accessed
-  # a leaf node in the code we return a regular String instead of the R18n classes.
-  class TextWrapper
-    def initialize(translation_tree)
-      @tree = translation_tree
-      @tree.translation_keys.each do |k|
-        # Integer keys are not translatable - they're quantity indicators in the key that
-        # are instead sent as arguments. If we see one here, it means it was not correctly
-        # labeled as plural with !!pl in the parent key
-        if k.class == Integer
-          raise MissingPlural.new(@tree.instance_variable_get(:@path), k)
-        end
+    def self.load
+      R18n.from_env(Text._translation_path)
+      R18n.extension_places << File.join(Text._translation_path, "errors")
+      t = R18n.get.t
+      t.translation_keys.each do |k|
         k = k.to_sym
         define_singleton_method k do |*args|
-          subtree = @tree.send(k, *args)
-          if subtree.translation_keys.empty?
-            # If there are no more possible children, just return the translated value
-            subtree.to_s
-          else
-            TextWrapper.new(subtree)
-          end
+          TextWrapper.new(t.send(k, *args))
         end
       end
     end
 
-    def method_missing(name, *args)
-      raise InvalidKey.new(@tree.instance_variable_get(:@path), name)
-    end
-
-    class TextError < RuntimeError
-      attr_accessor :line
-      def set_call_context
-        @line = caller(8, 1).first
-        if @line =~ /.*\/lib\/(.*\.rb):(\d+)/
-          @line = "File: #{$1} Line: #{$2}"
-        end
-      end
-    end
-
-    class InvalidKey < TextError
-      def initialize(path, terminus)
-        set_call_context
-        # Calling back into Text here seems icky, this is an error
-        # that only engineering should see.
-        message = "i18n key #{path}.#{terminus} does not exist.\n"
-        message << "Referenced from #{line}"
-        super(message)
-      end
-    end
-
-    class MissingPlural < TextError
-      def initialize(path, terminus)
-        set_call_context
-        # Calling back into Text here seems icky, this is an error
-        # that only engineering should see.
-        message = "i18n key #{path}.#{terminus} appears to reference a pluralization.\n"
-        message << "Please append the plural indicator '!!pl' to the end of #{path}.\n"
-        message << "Referenced from #{line}"
-        super(message)
-      end
-    end
-
+    # We need to do this when the class is loaded to avoid breaking a bunch of behaviors for now.
+    load
   end
+
 end

--- a/lib/chef_apply/text/text_wrapper.rb
+++ b/lib/chef_apply/text/text_wrapper.rb
@@ -1,0 +1,86 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefApply
+  module Text
+    # Our text spinner class really doesn't like handling the TranslatedString or Untranslated classes returned
+    # by the R18n library. So instead we return these TextWrapper instances which have dynamically defined methods
+    # corresponding to the known structure of the R18n text file. Most importantly, if a user has accessed
+    # a leaf node in the code we return a regular String instead of the R18n classes.
+    class TextWrapper
+      def initialize(translation_tree)
+        @tree = translation_tree
+        @tree.translation_keys.each do |k|
+          # Integer keys are not translatable - they're quantity indicators in the key that
+          # are instead sent as arguments. If we see one here, it means it was not correctly
+          # labeled as plural with !!pl in the parent key
+          if k.class == Integer
+            raise MissingPlural.new(@tree.instance_variable_get(:@path), k)
+          end
+          k = k.to_sym
+          define_singleton_method k do |*args|
+            subtree = @tree.send(k, *args)
+            if subtree.translation_keys.empty?
+              # If there are no more possible children, just return the translated value
+              subtree.to_s
+            else
+              TextWrapper.new(subtree)
+            end
+          end
+        end
+      end
+
+      def method_missing(name, *args)
+        raise InvalidKey.new(@tree.instance_variable_get(:@path), name)
+      end
+
+      # TODO - make the checks for these conditions lint steps that run during build
+      #        instead of part of the shipped product.
+      class TextError < RuntimeError
+        attr_accessor :line
+        def set_call_context
+          # TODO - this can vary (8 isn't always right) - inspect
+          @line = caller(8, 1).first
+          if @line =~ /.*\/lib\/(.*\.rb):(\d+)/
+            @line = "File: #{$1} Line: #{$2}"
+          end
+        end
+      end
+
+      class InvalidKey < TextError
+        def initialize(path, terminus)
+          set_call_context
+          # Calling back into Text here seems icky, this is an error
+          # that only engineering should see.
+          message = "i18n key #{path}.#{terminus} does not exist.\n"
+          message << "Referenced from #{line}"
+          super(message)
+        end
+      end
+
+      class MissingPlural < TextError
+        def initialize(path, terminus)
+          set_call_context
+          message = "i18n key #{path}.#{terminus} appears to reference a pluralization.\n"
+          message << "Please append the plural indicator '!!pl' to the end of #{path}.\n"
+          message << "Referenced from #{line}"
+          super(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/chef_apply/ui/error_printer.rb
+++ b/lib/chef_apply/ui/error_printer.rb
@@ -21,6 +21,7 @@ require "chef_apply/error"
 require "chef_apply/config"
 require "chef_apply/text"
 require "chef_apply/ui/terminal"
+require "chef_apply/errors/standard_error_resolver"
 
 module ChefApply::UI
   class ErrorPrinter
@@ -36,7 +37,7 @@ module ChefApply::UI
     def self.show_error(e)
       # Name is misleading - it's unwrapping but also doing further
       # error resolution for common errors:
-      unwrapped = ChefApply::StandardErrorResolver.unwrap_exception(e)
+      unwrapped = ChefApply::Errors::StandardErrorResolver.unwrap_exception(e)
       if unwrapped.class == ChefApply::MultiJobFailure
         capture_multiple_failures(unwrapped)
       end
@@ -51,7 +52,7 @@ module ChefApply::UI
       e.params << out_file # Tell the operator where to find this info
       File.open(out_file, "w") do |out|
         e.jobs.each do |j|
-          wrapped = ChefApply::StandardErrorResolver.wrap_exception(j.exception, j.target_host)
+          wrapped = ChefApply::Errors::StandardErrorResolver.wrap_exception(j.exception, j.target_host)
           ep = ErrorPrinter.new(wrapped)
           msg = ep.format_body().tr("\n", " ").gsub(/ {2,}/, " ").chomp.strip
           out.write("Host: #{j.target_host.hostname} ")

--- a/spec/unit/ui/error_printer_spec.rb
+++ b/spec/unit/ui/error_printer_spec.rb
@@ -17,6 +17,7 @@
 
 require "spec_helper"
 require "chef_apply/ui/error_printer"
+require "chef_apply/errors/standard_error_resolver"
 require "chef_apply/target_host"
 
 RSpec.describe ChefApply::UI::ErrorPrinter do
@@ -70,7 +71,7 @@ RSpec.describe ChefApply::UI::ErrorPrinter do
     context "when handling a MultiJobFailure" do
       it "recognizes it and invokes capture_multiple_failures" do
         underlying_error = ChefApply::MultiJobFailure.new([])
-        error_to_process = ChefApply::StandardErrorResolver.wrap_exception(underlying_error)
+        error_to_process = ChefApply::Errors::StandardErrorResolver.wrap_exception(underlying_error)
         expect(subject).to receive(:capture_multiple_failures).with(underlying_error)
         subject.show_error(error_to_process)
 
@@ -80,7 +81,7 @@ RSpec.describe ChefApply::UI::ErrorPrinter do
     context "when an error occurs in error handling" do
       it "processes the new failure with dump_unexpected_error" do
         error_to_raise = StandardError.new("this will be raised")
-        error_to_process = ChefApply::StandardErrorResolver.wrap_exception(StandardError.new("this is being shown"))
+        error_to_process = ChefApply::Errors::StandardErrorResolver.wrap_exception(StandardError.new("this is being shown"))
         # Intercept a known call to raise an error
         expect(ChefApply::UI::Terminal).to receive(:output).and_raise error_to_raise
         expect(subject).to receive(:dump_unexpected_error).with(error_to_raise)


### PR DESCRIPTION
### Description
Overdue minor housekeeping that splits out the TextWrapper and StandardErrorMapper classes into their own files. This also updates `Text` to be a module instead of a class. 

Once #15 merges, errors/en.yml will no longer show as a new file.
### Check List

- [x] ~New functionality includes tests~ (n/a - no new) 
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
