### PR TITLE
[SHACK-187] capture error metadata in translations instead of code 

### DIFF
--- a/i18n/errors/en.yml
+++ b/i18n/errors/en.yml
@@ -1,10 +1,32 @@
 # Error definitions, usage Text.e.ERR999
+#
 # General format:
+# ERRORID
+#   display: optional hash of display options. See display_defaults below.
+#   text: |
+#      text of the message
+#
 # First Line: brief description of the error
 # Second line: blank
 # Third+ : detailed description, max 76 characters per line
+
 errors:
-  rendering_defaults: {header: true, footer: true, stack: true, log: true}
+  # These are the default display attributes for all messages.
+  # If you want to override them for specific errors,
+  # you can do so as follows:
+  # EXAMPLERROR001:
+  #   display: { decorations: false }
+  #   text: |
+  #     Here is the message text.
+  display_defaults:
+    # Set 'decorations: false' in a message to show only text. Equivalent
+    # to setting all of the other attributes to false individually
+    decorations: true
+    stack: false # show reference to stack trace location in footer
+    log: false # show reference to log file location in footer
+    header: true  # Show error header (currently bolded error id)
+    footer: true # show standard footer
+
   # Catch-all for the worst case
   UNKNOWN: An unknown error has occurred.
 

--- a/lib/chef_apply/text.rb
+++ b/lib/chef_apply/text.rb
@@ -17,11 +17,20 @@
 
 require "r18n-desktop"
 require "chef_apply/text/text_wrapper"
+require "chef_apply/text/error_translation"
 
 # A very thin wrapper around R18n, the idea being that we're likely to replace r18n
 # down the road and don't want to have to change all of our commands.
 module ChefApply
   module Text
+    def self._error_table
+      # Though ther may be several translations, en.yml will be the only one with
+      # formatting metadata.
+      path = File.join(_translation_path, "errors", "en.yml")
+      raw_yaml = File.read(path)
+      @error_table ||= YAML.load(raw_yaml, _translation_path, symbolize_names: true)[:errors]
+    end
+
     def self._translation_path
       @translation_path ||= File.join(File.dirname(__FILE__), "..", "..", "i18n")
     end
@@ -38,8 +47,7 @@ module ChefApply
       end
     end
 
-    # We need to do this when the class is loaded to avoid breaking a bunch of behaviors for now.
+    # Load on class load to ensure our text accessor methods are available from the start.
     load
   end
-
 end

--- a/lib/chef_apply/text/error_translation.rb
+++ b/lib/chef_apply/text/error_translation.rb
@@ -1,0 +1,69 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefApply
+  module Text
+    class ErrorTranslation
+      ATTRIBUTES = :decorations, :header, :footer, :stack, :log
+      attr_reader :message, *ATTRIBUTES
+
+      def initialize(id, params: [])
+        # To get access to the metadata we'll go directly through the parsed yaml.
+        # Accessing via R18n is unnecessarily complicated
+        yml = Text._error_table
+
+        # We'll still use our Text mechanism for the text itself so that
+        # parameters, pluralization, etc will still work.
+        # This will raise if the key doesn't exist.
+        @message = Text.errors.send(id).text(*params)
+        options = yml[:display_defaults]
+
+        # Override any defaults if display metadata is given
+        display_opts = yml[id.to_sym][:display]
+        options = options.merge(display_opts) unless display_opts.nil?
+
+        ATTRIBUTES.each do |attribute|
+          instance_variable_set("@#{attribute}", options.delete(attribute))
+        end
+
+        if options.length > 0
+          # Anything not in ATTRIBUTES is not supported. This will also catch
+          # typos in attr names
+          raise InvalidDisplayAttributes.new(id, options)
+        end
+      end
+
+      def inspect
+        inspection = "#{self}: "
+        ATTRIBUTES.each do |attribute|
+          inspection << "#{attribute}: #{send(attribute.to_s)}; "
+        end
+        inspection << "message: #{message.gsub("\n", "\\n")}"
+        inspection
+      end
+
+      class InvalidDisplayAttributes < RuntimeError
+        attr_reader :invalid_attrs
+        def initialize(id, attrs)
+          @invalid_attrs = attrs
+          super("Invalid display attributes found for #{id}: #{attrs}")
+        end
+      end
+
+    end
+  end
+end

--- a/spec/unit/text/error_translation_spec.rb
+++ b/spec/unit/text/error_translation_spec.rb
@@ -1,0 +1,105 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef_apply/text"
+
+RSpec.describe ChefApply::Text::ErrorTranslation do
+
+  let(:display_defaults) do
+    {
+    decorations: true,
+    header: true,
+    footer: true,
+    stack: false,
+    log: false }
+  end
+
+  let(:error_table) do
+    { display_defaults: display_defaults,
+      TESTERROR: test_error } end
+
+  let(:test_error_text) { "This is a test error" }
+  let(:test_error) { {} }
+
+  subject { ChefApply::Text::ErrorTranslation }
+  let(:error_mock) do
+    double("R18n::Translated",
+                            text: test_error_text ) end
+  let(:translation_mock) do
+    double("R18n::Translated",
+                                 TESTERROR: error_mock,
+                                 text: test_error_text ) end
+  before do
+    # Mock out the R18n portion - our methods care only that the key exists, and
+    # the test focus is on the display metadata.
+    allow(ChefApply::Text).to receive(:errors).and_return translation_mock
+    allow(ChefApply::Text).to receive(:_error_table).and_return(error_table)
+  end
+
+  context "when some display attributes are specified" do
+    let(:test_error) { { display: { stack: true, log: true } } }
+    it "sets display attributes to specified values and defaults remaining" do
+      translation = subject.new("TESTERROR")
+      expect(translation.decorations).to be true
+      expect(translation.header).to be true
+      expect(translation.footer).to be true
+      expect(translation.stack).to be true
+      expect(translation.log).to be true
+      expect(translation.message).to eq test_error_text
+    end
+  end
+
+  context "when all display attributes are specified" do
+    let(:test_error) do
+      { display: { decorations: false, header: false,
+                   footer: false, stack: true, log: true } } end
+    it "sets display attributes to specified values with no defaults" do
+      translation = subject.new("TESTERROR")
+      expect(translation.decorations).to be false
+      expect(translation.header).to be false
+      expect(translation.footer).to be false
+      expect(translation.stack).to be true
+      expect(translation.log).to be true
+      expect(translation.message).to eq test_error_text
+    end
+  end
+
+  context "when no attributes for an error are specified" do
+    let(:test_error) { {} }
+    it "sets display attribute to default values and references the correct message" do
+      translation = subject.new("TESTERROR")
+      expect(translation.decorations).to be true
+      expect(translation.header).to be true
+      expect(translation.footer).to be true
+      expect(translation.stack).to be false
+      expect(translation.log).to be false
+      expect(translation.message).to eq test_error_text
+    end
+  end
+
+  context "when invalid attributes for an error are specified" do
+    let(:test_error) { { display: { bad_value: true } } }
+    it "raises InvalidDisplayAttributes when invalid attributes are specified" do
+      expect { subject.new("TESTERROR") }
+        .to raise_error(ChefApply::Text::ErrorTranslation::InvalidDisplayAttributes) do |e|
+        expect(e.invalid_attrs).to eq({ bad_value: true })
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
### Description

This is the first part of decoupling error display/rendering options
from the code. This sets us up to move error display options to live
with the error definitions in i18n/errors/en.yml.

A new class ErrorTranslation encapsulates error messages translations,
providing access to both the text and the display attributes.

Note that this commit does not convert any messages or remove the
various convenience exceptions (such as ErrorNoLog) - that will follow
this work shortly.

This PR is one commit - once #16 merges, that'll be more clear. 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
