### PR TITLE
[SHACK-187] convert error handling to use new encapsulated display data

### DIFF
--- a/i18n/errors/en.yml
+++ b/i18n/errors/en.yml
@@ -1,3 +1,19 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Error definitions, usage Text.e.ERR999
 #
 # General format:
@@ -9,6 +25,16 @@
 # First Line: brief description of the error
 # Second line: blank
 # Third+ : detailed description, max 76 characters per line
+
+# Pluralizing Messages
+# If the text of an error differs based on quantity of subject,
+# you can specify different messages as follows:
+# ERRORID
+#   text: !!pl
+#     0: You have no things.
+#     1: You have one thing.
+#     n: You have lots of things.
+# Text.ERRORID(quanity, [other formatting params])
 
 errors:
   # These are the default display attributes for all messages.
@@ -28,10 +54,13 @@ errors:
     footer: true # show standard footer
 
   # Catch-all for the worst case
-  UNKNOWN: An unknown error has occurred.
+  UNKNOWN:
+    display: { stack: true, log: true }
+    text: An unknown error has occurred.
 
   # Installer action errors
   CHEFINS002:
+    text: |
       The target does not have chef-client installed.
 
       This command is powered by the Chef client.  In order to make use of it
@@ -52,291 +81,355 @@ errors:
     Version %1 is installed, but this command requires a
     minimum version of %2.
 
-  # Local errors trying to create policy to send to target
-  CHEFPOLICY001: |
-    Could not create local Policyfile bundle.
+  CHEFINS003:
+    text: |
+      The target has an older version of Chef client installed.
 
-    The following error was reported:
+      The target has version %1 installed, but this command
+      requires a minimum version of %2.
 
-      %1
+      Please upgrade the Chef client on this node to version %2 or later.
 
-  # Remote execution and file operation errors are prefixed CHEFRMT
-  CHEFRMT001: |
-    The command '%1' exited with return code '%2' on '%3'.
+# Local errors trying to create policy to send to target
+  CHEFPOLICY001:
+    display: { stack: true, log: true }
+    text: |
+      Could not create local Policyfile bundle.
 
-    The following error was reported:
+      The following error was reported:
+
+        %1
+
+# Remote execution and file operation errors are prefixed CHEFRMT
+  CHEFRMT001:
+    text: |
+      The command '%1' exited with return code '%2' on '%3'.
+
+      The following error was reported:
 
       %4
 
   # Remote chef client run failure start here.
-  CHEFCCR001: |
-    Could not determine reason for converge failure.
+  CHEFCCR001:
+    text: |
+      Could not determine reason for converge failure.
 
-    STDOUT (may be blank)
+      STDOUT (may be blank)
 
-      %1
+        %1
 
-    STDERR (may be blank)
+      STDERR (may be blank)
 
-      %2
+        %2
 
-    An error occurred while converging the remote host.
-    I was unable to retrieve the log file which would allow
-    me to provide more information.  Above is the output
-    that occurred while trying to retrieve the remote log file.
+      An error occurred while converging the remote host.
+      I was unable to retrieve the log file which would allow
+      me to provide more information.  Above is the output
+      that occurred while trying to retrieve the remote log file.
 
-  CHEFCCR002: |
-    The converge of the remote host failed for the
-    following reason:
+  CHEFCCR002:
+    text: |
+      The converge of the remote host failed for the
+      following reason:
 
-      %1
+        %1
 
-  CHEFCCR003: |
-    The action '%1' is not valid.
+  CHEFCCR003:
+    text: |
+      The action '%1' is not valid.
 
-    Valid actions are:
+      Valid actions are:
 
-      %2
+        %2
 
-    For more information, please consult the documentation
-    for this resource:
+      For more information, please consult the documentation
+      for this resource:
 
-      https://docs.chef.io/resource_reference.html
+        https://docs.chef.io/resource_reference.html
 
-  CHEFCCR004: |
-    A property value you provided is not valid:
+  CHEFCCR004:
+    text: |
+      A property value you provided is not valid:
 
-      %1
+        %1
 
-    Please consult the documentation for properties
-    supported by your resource and their valid values:
+      Please consult the documentation for properties
+      supported by your resource and their valid values:
 
-      https://docs.chef.io/resource_reference.html
+        https://docs.chef.io/resource_reference.html
 
-  CHEFCCR005: |
-    '%1' is not a valid Chef resource.
+  CHEFCCR005:
+    text: |
+      '%1' is not a valid Chef resource.
 
-    Please consult the documentation for a list of valid resources:
+      Please consult the documentation for a list of valid resources:
 
-      https://docs.chef.io/resource_reference.html
+        https://docs.chef.io/resource_reference.html
 
-  CHEFCCR006: |
-    '%1' is not a property of '%2'.
+  CHEFCCR006:
+    text: |
+      '%1' is not a property of '%2'.
 
-    Please consult the documentation for %2 for a list of
-    valid properties:
+      Please consult the documentation for %2 for a list of
+      valid properties:
 
-      https://docs.chef.io/resource_reference.html
+        https://docs.chef.io/resource_reference.html
 
-  CHEFCCR099: |
-    The converge of the remote host failed.
+  CHEFCCR099:
+    text: |
+      The converge of the remote host failed.
 
-    Please examine the log file for a detailed cause of failure.
+      Please examine the log file for a detailed cause of failure.
 
   # Train-related errors (connectivy, auth failure, etc)
   # are prefixed CHEFTRN. Non-specific descendants of Train::Error
   # will resolve to CHEFTRN001, and we can add additional
   # more specific text as we need it.
-  CHEFTRN001: |
-    An error has occurred on the %1 connection to %2:
+  CHEFTRN001:
+    text: |
+      An error has occurred on the %1 connection to %2:
 
-    %2.
+      %2.
 
-  CHEFTRN002: |
-    An remote error has occurred:
+  CHEFTRN002:
+    text: |
+      An remote error has occurred:
 
-      %1.
+        %1.
 
-  CHEFTRN003: |
-    Password required for sudo.
+  CHEFTRN003:
+    text: |
+      Password required for sudo.
 
-    This target requires a password to perform sudo operations.  Please provide a
-    password using the --sudo-password option. For example if the sudo password is
-    in the environment variable $CHEF_RUN_SUDO_PASSWORD, you could use:
+      This target requires a password to perform sudo operations.  Please provide a
+      password using the --sudo-password option. For example if the sudo password is
+      in the environment variable $CHEF_RUN_SUDO_PASSWORD, you could use:
 
-    --sudo-password $CHEF_RUN_SUDO_PASSWORD
+      --sudo-password $CHEF_RUN_SUDO_PASSWORD
 
-  CHEFTRN004: |
-    Incorrect sudo password provided.
+  CHEFTRN004:
+    text: |
+      Incorrect sudo password provided.
 
-    Please ensure that the password you provided with "--sudo-password" is correct.
+      Please ensure that the password you provided with "--sudo-password" is correct.
 
-  CHEFTRN005: |
-    sudo command '%1' not found.
+  CHEFTRN005:
+    text: |
+      sudo command '%1' not found.
 
-    Please verify that the --sudo-command '%1' is valid
-    and installed on this node.
+      Please verify that the --sudo-command '%1' is valid
+      and installed on this node.
 
-  CHEFTRN006: |
-    sudo requires tty on this system
+  CHEFTRN006:
+    text: |
+      sudo requires tty on this system
 
-    In order to continue, sudo must be configured to no longer require tty.
-    You can do this by modifying /etc/sudoers:
+      In order to continue, sudo must be configured to no longer require tty.
+      You can do this by modifying /etc/sudoers:
 
-    For all users:
-      Defaults !requiretty
+      For all users:
+        Defaults !requiretty
 
-    Per-user:
-      Defaults:username !requiretty
+      Per-user:
+        Defaults:username !requiretty
 
-  CHEFTRN007: |
-    No authentication methods available.
+  CHEFTRN007:
+    text: |
+      No authentication methods available.
 
-    Try...
-    - Provide a password with "--password PASSWORD"
-    - Provide a key with "-identity-file PATH/TO/FILE"
-    - Enable ssh-agent and add keys
-    - Add a host entry to your ssh configuration
+      Try...
+      - Provide a password with "--password PASSWORD"
+      - Provide a key with "-identity-file PATH/TO/FILE"
+      - Enable ssh-agent and add keys
+      - Add a host entry to your ssh configuration
 
-    Additional instructions can be found in the troubleshooting documentation:
+      Additional instructions can be found in the troubleshooting documentation:
 
-    https://www.chef.sh/docs/chef-workstation/troubleshooting/#error-code-cheftrn007
+      https://www.chef.sh/docs/chef-workstation/troubleshooting/#error-code-cheftrn007
 
-  CHEFTRN999: |
-    Connection failed: %1
+  CHEFTRN999:
+    text: |
+      Connection failed: %1
 
-    The following error occured while attempting to connect and authenticate to the target.
+      The following error occured while attempting to connect and authenticate to the target.
 
-    %1
+      %1
 
   # CLI argument validation errors
-  CHEFVAL002: |
-    You must supply <TARGET[S]> and either <RESOURCE> and <RESOURCE_NAME> or <RECIPE>
+  CHEFVAL002:
+    display: { decorations: false }
+    text: |
+      You must supply <TARGET[S]> and either <RESOURCE> and <RESOURCE_NAME> or <RECIPE>
 
-  CHEFVAL003: |
-    Property '%1' did not match the 'key=value' syntax required
+  CHEFVAL003:
+    display: { decorations: false }
+    text: |
+      Property '%1' did not match the 'key=value' syntax required
 
-  CHEFVAL004: |
-    Please provide a recipe in the form 'path/to/recipe/file.rb',
-    'path/to/cookbook', 'cookbook_name' or 'cookbook_name::recipe_name'.
+  CHEFVAL004:
+    display: { decorations: false }
+    text: |
+      Please provide a recipe in the form 'path/to/recipe/file.rb',
+      'path/to/cookbook', 'cookbook_name' or 'cookbook_name::recipe_name'.
 
-    You provided '%1'.
+      You provided '%1'.
 
-  CHEFVAL005: |
-    The cookbook provided could not be loaded. Ensure it contains a valid
-    'metadata.rb'.
+  CHEFVAL005:
+    display: { decorations: false }
+    text: |
+      The cookbook provided could not be loaded. Ensure it contains a valid
+      'metadata.rb'.
 
-    Cookbook path is '%1'.
+      Cookbook path is '%1'.
 
-  CHEFVAL006: |
-    Cookbook '%1' could not be found in any of the following directories
-
-    %2
-
-  CHEFVAL007: |
-    There is no default recipe in cookbook '%2'. Please provide the name of the recipe to run, for example:
-      %2::some_recipe
-
-    Cookbook path is '%1'.
-
-  CHEFVAL008: |
-    There is no recipe named '%2' in the cookbook '%4', which I found at '%1'.
-
-    Please include the name of the recipe you wish to converge on the remote target.
-
-    These are the available recipes in '%4':
-    %3
-
-  CHEFVAL009: |
-    File extension '%1' is unsupported. Currently recipes must be specified with a `.rb` extension.
-
-  CHEFVAL010: |
-    The flag '%1' does not exist.
-
-      Available flags are:
-    %2
-
-  CHEFVAL011: |
-    The protocol '%1' is not supported.
-
-    Currently supported remote access protocols are:
+  CHEFVAL006:
+    display: { decorations: false }
+    text: |
+      Cookbook '%1' could not be found in any of the following directories
 
       %2
 
-  # General errors/unknown errors are handled with CHEFINT
-  CHEFINT001: |
-    An unexpected error has occurred:
+  CHEFVAL007:
+    display: { decorations: false }
+    text: |
+      There is no default recipe in cookbook '%2'. Please provide the name of the recipe to run, for example:
+        %2::some_recipe
 
-      %1
+      Cookbook path is '%1'.
+
+  CHEFVAL008:
+    display: { decorations: false }
+    text: |
+      There is no recipe named '%2' in the cookbook '%4', which I found at '%1'.
+
+      Please include the name of the recipe you wish to converge on the remote target.
+
+      These are the available recipes in '%4':
+      %3
+
+  CHEFVAL009:
+    display: { decorations: false }
+    text: |
+      File extension '%1' is unsupported. Currently recipes must be specified with a `.rb` extension.
+
+  CHEFVAL010:
+    display: { decorations: false }
+    text: |
+      The flag '%1' does not exist.
+
+      Available flags are:
+        %2
+
+  CHEFVAL011:
+    display: { decorations: false }
+    text: |
+      The protocol '%1' is not supported.
+
+      Currently supported remote access protocols are:
+
+        %2
+
+  # General errors/unknown errors are handled with CHEFINT
+  CHEFINT001:
+    display: { log: true, stack: true }
+    text: |
+      An unexpected error has occurred:
+
+        %1
 
   # Internal API errors - give them some formatting
-  CHEFAPI001: |
-    API error: provide either :recipe_spec or :resouce_name, :resource_type,
-    and :resource_properties
+  CHEFAPI001:
+    display: { log: true, stack: true }
+    text: |
+      API error: provide either :recipe_spec or :resouce_name, :resource_type,
+      and :resource_properties
 
-    You provided: %1
+      You provided: %1
 
 
   # Maps to: NameError
-  CHEFNET001: |
-    A network error occurred:
+  CHEFNET001:
+    text: |
+      A network error occurred:
 
-      %1
+        %1
 
-    Please verify the host name or address is correct and that the host is
-    reachable before trying again.
+      Please verify the host name or address is correct and that the host is
+      reachable before trying again.
 
   # Remote chef client run failure start here.
-  CHEFUPL003: |
-    Uploading config to target failed.
+  CHEFUPL003:
+    display: { log: true, stack: true }
+    text: |
+      Uploading config to target failed.
 
-  CHEFUPL004: |
-    Uploading handler to target failed.
+  CHEFUPL004:
+    display: { log: true, stack: true }
+    text: |
+      Uploading handler to target failed.
 
-  CHEFUPL005: |
-    Uploading policy bundle to target failed.
+  CHEFUPL005:
+    display: { log: true, stack: true }
+    text: |
+      Uploading policy bundle to target failed.
 
   # Maps to: SSL::SSLError with message text indicating verification failure
-  CHEFNET002: |
-    SSL host verification failed.
+  CHEFNET002:
+    text: |
+      SSL host verification failed.
 
-    I could not verify the identity of the remote host.
+      I could not verify the identity of the remote host.
 
-    If you are certain that you are connecting to the correct host,
-    you can specify the '--no-ssl-verify' option for this command, or
-    make it the default by setting the following in your configuration:
+      If you are certain that you are connecting to the correct host,
+      you can specify the '--no-ssl-verify' option for this command, or
+      make it the default by setting the following in your configuration:
 
-      [connection.winrm]
-      ssl_verify=false
+        [connection.winrm]
+        ssl_verify=false
 
   # Errors specifying target ranges
   CHEFRANGE001: |
-    The target '%1' contains an invalid range.
+    text: |
+      The target '%1' contains an invalid range.
 
-    The range '%2' mixes alphabetic and numeric values.
-    A range must be one or the other.
+      The range '%2' mixes alphabetic and numeric values.
+      A range must be one or the other.
 
   CHEFRANGE002:
-    The target '%1' contains too many ranges.
+    text: |
+      The target '%1' contains too many ranges.
 
-    A single target name can contain up two ranges.
+      A single target name can contain up two ranges.
 
-  CHEFRANGE003: !!pl
-    1:
-      The target provided resolves to too many hosts.
+  CHEFRANGE003:
+    text: !!pl
+      1:
+        The target provided resolves to too many hosts.
 
-      At this time there is a limit of %2 hosts in a single operation.
-    n:
-      The targets provided resolve to too many hosts.
+        At this time there is a limit of %2 hosts in a single operation.
+      n:
+        The targets provided resolve to too many hosts.
 
-      At this time there is a limit of %2 hosts in a single operation.
+        At this time there is a limit of %2 hosts in a single operation.
 
   # Errors related to multi-target execution
-  CHEFMULTI001: |
-    One or more actions has failed.
+  CHEFMULTI001:
+    text: |
+      One or more actions has failed.
 
-    A complete list of failures and possible resolutions can
-    be found in the file below:
+      A complete list of failures and possible resolutions can
+      be found in the file below:
 
-      %1
+        %1
 
   # Errors relating to target state:
-  CHEFTARG001: |
-    '%1' is not a supported target operating system at this time.
+  CHEFTARG001:
+    text: |
+      '%1' is not a supported target operating system at this time.
 
-    We plan to support a range of target operating systems,
-    but during this targeted beta we are constraining our efforts
-    to Windows and Linux.
+      We plan to support a range of target operating systems,
+      but during this targeted beta we are constraining our efforts
+      to Windows and Linux.
 
 
   footer:

--- a/lib/chef_apply/text.rb
+++ b/lib/chef_apply/text.rb
@@ -25,7 +25,7 @@ module ChefApply
   module Text
     def self._error_table
       # Though ther may be several translations, en.yml will be the only one with
-      # formatting metadata.
+      # error metadata.
       path = File.join(_translation_path, "errors", "en.yml")
       raw_yaml = File.read(path)
       @error_table ||= YAML.load(raw_yaml, _translation_path, symbolize_names: true)[:errors]


### PR DESCRIPTION
### Description

Move error display attributes into translation yml

This is the first part of decoupling error display/rendering options
from the code. This sets us up to move error display options to live
with the error definitions in i18n/errors/en.yml.

A new class ErrorTranslation encapsulates error messages translations,
providing access to both the text and the display attributes.

Note that this commit does not convert any messages or remove the
various convenience exceptions (such as ErrorNoLog) - that will follow
this work shortly.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
