### PR TITLE
[SHACK-290] Support installed version of Chef 13 if 13.10 or greater

### DIFF
--- a/i18n/errors/en.yml
+++ b/i18n/errors/en.yml
@@ -19,12 +19,16 @@ errors:
       automatically perform the installation.
 
   CHEFINS003: |
-    The target has an older version of Chef client installed.
+    The target's installed version of Chef Client is too old.
 
-    The target has version %1 installed, but this command
-    requires a minimum version of %2.
+    Version %1 is installed, but this command requires a
+    minimum version of %2 (Chef 13) or %3 (Chef 14).
 
-    Please upgrade the Chef client on this node to version %2 or later.
+  CHEFINS004: |
+    The target's installed version of Chef Client is too old.
+
+    Version %1 is installed, but this command requires a
+    minimum version of %2.
 
   # Local errors trying to create policy to send to target
   CHEFPOLICY001: |

--- a/lib/chef_apply/cli/options.rb
+++ b/lib/chef_apply/cli/options.rb
@@ -115,7 +115,7 @@ module ChefApply
           long: "--[no-]install",
           default: true,
           boolean: true,
-          description:  T.install_description(Action::InstallChef::Base::MIN_CHEF_VERSION)
+          description:  T.install_description
 
         klass.option :sudo,
           long: "--[no-]sudo",

--- a/spec/unit/action/install_chef/base_spec.rb
+++ b/spec/unit/action/install_chef/base_spec.rb
@@ -48,55 +48,25 @@ RSpec.describe ChefApply::Action::InstallChef::Base do
   end
 
   context "#perform_action" do
-    context "when chef is already installed on target at the correct minimum version" do
-      before do
-        expect(install.target_host).to receive(:installed_chef_version).and_return ChefApply::Action::InstallChef::Base::MIN_CHEF_VERSION
-      end
+    context "when chef is already installed on target" do
       it "notifies of success and takes no further action" do
+        expect(install).to receive(:check_minimum_chef_version!).with(install.target_host)
+                       .and_return(:minimum_version_met)
         expect(install).not_to receive(:perform_local_install)
         install.perform_action
       end
     end
 
-    context "when chef is already installed on target at a version that's too low" do
-      before do
-        expect(install.target_host).to receive(:installed_chef_version).
-          and_return Gem::Version.new("12.1.1")
-      end
-      # 2018-05-10  pended until we determine how we want auto-upgrades to behave
-      xit "performs the upgrade" do
+    context "when chef is not already installed on target" do
+      it "should invoke perform_local_install" do
+        expect(install).to receive(:check_minimum_chef_version!).with(install.target_host)
+                       .and_return(:client_not_installed)
         expect(install).to receive(:perform_local_install)
         install.perform_action
       end
     end
-
-    context "when chef is not already installed on target" do
-      before do
-        expect(install.target_host).to receive(:installed_chef_version).
-          and_raise ChefApply::TargetHost::ChefNotInstalled.new
-      end
-
-      context "on windows" do
-        let(:mock_os_name) { "Windows_Server" }
-        let(:mock_os_family) { "windows" }
-        let(:mock_os_releae) { "10.0.1" }
-
-        it "should invoke perform_local_install" do
-          expect(install).to receive(:perform_local_install)
-          install.perform_action
-        end
-      end
-
-      context "on anything else" do
-        let(:mock_os_name) { "Ubuntu" }
-        let(:mock_os_family) { "debian" }
-        it "should invoke perform_local_install" do
-          expect(install).to receive(:perform_local_install)
-          install.perform_action
-        end
-      end
-    end
   end
+
   context "#perform_local_install" do
     let(:artifact) { double("artifact") }
     let(:package_url) { "https://chef.io/download/package/here" }
@@ -190,6 +160,73 @@ RSpec.describe ChefApply::Action::InstallChef::Base do
           mixlib_info = install.train_to_mixlib(platform)
           expect(mixlib_info[:platform]).to eq "el"
           expect(mixlib_info[:platform_version]).to eq "7"
+        end
+      end
+    end
+  end
+
+  context "#check_minimum_chef_version!" do
+    let(:target) { install.target_host }
+    context "when chef is not already installed on target" do
+      before do
+        expect(target).to receive(:installed_chef_version).
+          and_raise ChefApply::TargetHost::ChefNotInstalled.new
+      end
+
+      it "should return :client_not_installed" do
+        actual = install.check_minimum_chef_version!(target)
+        expect(:client_not_installed).to eq(actual)
+      end
+
+      context "when config is set to check_only" do
+        after do
+          install.config.clear
+        end
+
+        it "raises ClientNotInstalled" do
+          install.config[:check_only] = true
+          expect do
+            install.check_minimum_chef_version!(target)
+          end.to raise_error(ChefApply::Action::InstallChef::ClientNotInstalled)
+        end
+      end
+    end
+
+    min_14_version = ChefApply::Action::InstallChef::Base::MIN_14_VERSION
+    min_13_version = ChefApply::Action::InstallChef::Base::MIN_13_VERSION
+    context "when chef is already installed on target at the correct minimum Chef 14 version" do
+      before do
+        expect(target).to receive(:installed_chef_version).and_return min_14_version
+      end
+      it "should return :minimum_version_met" do
+        actual = install.check_minimum_chef_version!(target)
+        expect(:minimum_version_met).to eq(actual)
+      end
+    end
+
+    context "when chef is already installed on target at the correct minimum Chef 13 version" do
+      before do
+        expect(target).to receive(:installed_chef_version).and_return min_13_version
+      end
+      it "should return :minimum_version_met" do
+        actual = install.check_minimum_chef_version!(target)
+        expect(:minimum_version_met).to eq(actual)
+      end
+    end
+
+    installed_expected = {
+      Gem::Version.new("12.1.1") => ChefApply::Action::InstallChef::Client13Outdated,
+      Gem::Version.new("13.9.0") => ChefApply::Action::InstallChef::Client13Outdated,
+      Gem::Version.new("14.1.0") => ChefApply::Action::InstallChef::Client14Outdated,
+    }
+    installed_expected.each do |installed, expected|
+      context "when chef is already installed on target at version #{installed}" do
+        before do
+          expect(target).to receive(:installed_chef_version).
+            and_return installed
+        end
+        it "notifies of failure and takes no further action" do
+          expect { install.check_minimum_chef_version!(target) }.to raise_error(expected)
         end
       end
     end


### PR DESCRIPTION
### Description

For users with an existing Chef Client 13 at version 13.10 or greater we
should not fail out. This version of Chef Client has the necessary fixes
to execute the chef-run policyfile bundle successfully.

### Issues Resolved

SHACK-290

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change

Signed-off-by: tyler-ball <tball@chef.io>