### PR TITLE
Fixed the propagation of log_level

### DIFF
--- a/lib/chef_apply/log.rb
+++ b/lib/chef_apply/log.rb
@@ -22,7 +22,6 @@ module ChefApply
     extend Mixlib::Log
 
     def self.setup(location, log_level)
-      @location = location
       if location.is_a?(String)
         if location.casecmp("stdout") == 0
           location = $stdout
@@ -30,6 +29,7 @@ module ChefApply
           location = File.open(location, "w+")
         end
       end
+      @location = location
       init(location)
       Log.level = log_level
     end

--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -165,7 +165,7 @@ module ChefApply
       ChefConfig.logger = ChefApply::Log
       # Setting the config isn't enough, we need to ensure the logger is initialized
       # or automatic initialization will still go to stdout
-      Chef::Log.init(ChefApply::Log)
+      Chef::Log.init(ChefApply::Log.location)
       Chef::Log.level = ChefApply::Log.level
     end
 


### PR DESCRIPTION
### Description
Some code shuffling to enable honouring the `log.level` config setting throughout a chef-apply (`chef-run`) run.

### Issues Resolved
This aims at fixing #23.

### Check List

- [ ] New functionality includes tests (N/A)
- [ ] All tests pass (Haven't run any, dev env setup instructions missing (but mentioned in readme), though changes are very scope-limited)
- [ ] PR title is a worthy inclusion in the CHANGELOG (Probably not)
- [ ] You have locally validated the change (YES)
