### PR TITLE
Changed log level requirement for target host output

### DIFF
--- a/lib/chef_apply/action/converge_target.rb
+++ b/lib/chef_apply/action/converge_target.rb
@@ -40,7 +40,7 @@ module ChefApply::Action
       c = target_host.run_command(cmd_str)
       target_host.run_command!("#{delete_folder} #{remote_dir_path}")
       if c.exit_status == 0
-        ChefApply::Log.debug(c.stdout)
+        ChefApply::Log.info(c.stdout)
         notify(:success)
       elsif c.exit_status == 35
         notify(:reboot)


### PR DESCRIPTION
Signed-off-by: Antoine Mazeas <antoine@karthanis.net>

### Description
In the converge step, `chef-apply` only outputs the received log from the target host with `Log.debug`. This is changed to `Log.info`.

As discussed in the related issue (#28), the target host's output is perhaps more important than `chef-apply`'s debug output, so this change reflects that. This also limits the noise around the target host's output.

### Issues Resolved
This aims at resolving #28.

### Check List

- [ ] New functionality includes tests (no new tests)
- [x] All tests pass 
- [ ] PR title is a worthy inclusion in the CHANGELOG (perhaps)
- [x] You have locally validated the change
