### PR TITLE
[SHACK-304] Promote chef-apply gem to Rubygems on every successful PR merge

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -34,7 +34,14 @@ merge_actions:
   - built_in:build_gem:
       only_if:
         - built_in:bump_version
+  - built_in:publish_rubygems:
+      only_if:
+        - built_in:build_gem
 
-promote:
-  action:
-    - built_in:publish_rubygems
+# While we're in beta and it takes a long series of steps to promote Chef Workstation
+# (release chef-apply to rubygems, update ChefDK dependencies, perform a Chef Workstation
+# build and then promote that) we want to minimize manual gates. So every successful
+# PR merge will promote to Rubygems at this point.
+# promote:
+#   action:
+#     - built_in:publish_rubygems

--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -64,4 +64,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-stack_explorer"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "chefstyle"
+
+  spec.post_install_message = File.read(File.expand_path("../warning.txt", __FILE__))
 end

--- a/warning.txt
+++ b/warning.txt
@@ -1,0 +1,3 @@
+Chef Apply is not meant to be installed as a gem. It is meant to be installed
+as part of the Chef Workstation omnibus package. Please download and install
+that from https://downloads.chef.io/chef-dk/


### PR DESCRIPTION
### Description

This is the first PR needed for SHACK-304. Promoting the `chef-apply` gem on every PR merge means that all we need to do in ChefDK is update dependencies to get the latest set of changes to `chef-apply`.

### Issues Resolved

SHACK-304

### Check List

- [ ] (N/A) New functionality includes tests
- [ ] (N/A)All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
