### PR TITLE
[SHACK-304] Expeditor cannot auto-promote for us

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -34,14 +34,7 @@ merge_actions:
   - built_in:build_gem:
       only_if:
         - built_in:bump_version
-  - built_in:publish_rubygems:
-      only_if:
-        - built_in:build_gem
 
-# While we're in beta and it takes a long series of steps to promote Chef Workstation
-# (release chef-apply to rubygems, update ChefDK dependencies, perform a Chef Workstation
-# build and then promote that) we want to minimize manual gates. So every successful
-# PR merge will promote to Rubygems at this point.
-# promote:
-#   action:
-#     - built_in:publish_rubygems
+promote:
+  action:
+    - built_in:publish_rubygems


### PR DESCRIPTION
### Description

We will need to manually promote our gem to Rubygems. This is a partial revert of https://github.com/chef/chef-apply/pull/31

### Issues Resolved

SHACK-304

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
