### PR TITLE
[SHACK-290] Set minimum Chef 13 version to be 13.10.4 (fix policyfile tarball use on Windows)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,8 @@ Vagrant.configure("2") do |config|
         # disable logging client console on host
         v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
       end
+      node.vm.provision "shell", inline: "echo 'MaxAuthTries 25' >> /etc/ssh/sshd_config"
+      node.vm.provision "shell", inline: "service sshd restart"
     end
   end
 

--- a/lib/chef_apply/action/base.rb
+++ b/lib/chef_apply/action/base.rb
@@ -88,19 +88,19 @@ module ChefApply
       # Chef 13 on Linux requires full path specifiers for --config and --recipe-url while on Chef 13 and 14 on
       # Windows must use relative specifiers to prevent URI from causing an error
       # (https://github.com/chef/chef/pull/7223/files).
-      def run_chef(working_dir, config, policy)
+      def run_chef(working_dir, config_file, policy)
         case family
         when :windows
           "Set-Location -Path #{working_dir}; " +
             # We must 'wait' for chef-client to finish before changing directories and Out-Null does that
-            "chef-client -z --config #{config} --recipe-url #{policy} | Out-Null; " +
+            "chef-client -z --config #{File.join(working_dir, config_file)} --recipe-url #{File.join(working_dir, policy)} | Out-Null; " +
             # We have to leave working dir so we don't hold a lock on it, which allows us to delete this tempdir later
             "Set-Location C:/; " +
             "exit $LASTEXITCODE"
         else
           # cd is shell a builtin, so much call bash. This also means all commands are executed
           # with sudo (as long as we are hardcoding our sudo use)
-          "bash -c 'cd #{working_dir}; chef-client -z --config #{File.join(working_dir, config)} --recipe-url #{File.join(working_dir, policy)}'"
+          "bash -c 'cd #{working_dir}; chef-client -z --config #{File.join(working_dir, config_file)} --recipe-url #{File.join(working_dir, policy)}'"
         end
       end
 

--- a/lib/chef_apply/minimum_chef_version.rb
+++ b/lib/chef_apply/minimum_chef_version.rb
@@ -1,0 +1,79 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef_apply/error"
+
+module ChefApply
+  class MinimumChefVersion
+
+    CONSTRAINTS = {
+      windows: {
+        13 => Gem::Version.new("13.10.4"),
+        14 => Gem::Version.new("14.4.22")
+      },
+      linux: {
+        13 => Gem::Version.new("13.10.4"),
+        14 => Gem::Version.new("14.1.1")
+      }
+    }
+
+    def self.check!(target, check_only)
+      begin
+        installed_version = target.installed_chef_version
+      rescue ChefApply::TargetHost::ChefNotInstalled
+        if check_only
+          raise ClientNotInstalled.new()
+        end
+        return :client_not_installed
+      end
+
+      os_constraints = CONSTRAINTS[target.base_os]
+      min_14_version = os_constraints[14]
+      min_13_version = os_constraints[13]
+
+      case
+        when installed_version >= Gem::Version.new("14.0.0") && installed_version < min_14_version
+          raise Client14Outdated.new(installed_version, min_14_version)
+        when installed_version >= Gem::Version.new("13.0.0") && installed_version < min_13_version
+          raise Client13Outdated.new(installed_version, min_13_version, min_14_version)
+        when installed_version < Gem::Version.new("13.0.0")
+          # If they have Chef < 13.0.0 installed we want to show them the easiest upgrade path -
+          # Chef 13 first and then Chef 14 since most customers cannot make the leap directly
+          # to 14.
+          raise Client13Outdated.new(installed_version, min_13_version, min_14_version)
+      end
+
+      :minimum_version_met
+    end
+
+    class ClientNotInstalled < ChefApply::ErrorNoLogs
+      def initialize(); super("CHEFINS002"); end
+    end
+
+    class Client13Outdated < ChefApply::ErrorNoLogs
+      def initialize(current_version, min_13_version, min_14_version)
+        super("CHEFINS003", current_version, min_13_version, min_14_version)
+      end
+    end
+
+    class Client14Outdated < ChefApply::ErrorNoLogs
+      def initialize(current_version, target_version)
+        super("CHEFINS004", current_version, target_version)
+      end
+    end
+  end
+end

--- a/spec/unit/action/base_spec.rb
+++ b/spec/unit/action/base_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ChefApply::Action::Base do
     it "correctly returns chef run string" do
       expect(action.run_chef("a", "b", "c")).to eq(
         "Set-Location -Path a; " \
-        "chef-client -z --config b --recipe-url c | Out-Null; " \
+        "chef-client -z --config #{File.join("a", "b")} --recipe-url #{File.join("a", "c")} | Out-Null; " \
         "Set-Location C:/; " \
         "exit $LASTEXITCODE"
       )

--- a/spec/unit/minimum_chef_version_spec.rb
+++ b/spec/unit/minimum_chef_version_spec.rb
@@ -1,0 +1,90 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef_apply/minimum_chef_version"
+require "chef_apply/target_host"
+require "spec_helper"
+
+RSpec.describe ChefApply::MinimumChefVersion do
+  let(:base_os) { :linux }
+  let(:version) { 14 }
+  let(:target) { instance_double(ChefApply::TargetHost, base_os: base_os, installed_chef_version: version) }
+  subject(:klass) { ChefApply::MinimumChefVersion }
+
+  context "#check!" do
+    context "when chef is not already installed on target" do
+      before do
+        expect(target).to receive(:installed_chef_version).
+          and_raise ChefApply::TargetHost::ChefNotInstalled.new
+      end
+
+      it "should return :client_not_installed" do
+        actual = klass.check!(target, false)
+        expect(:client_not_installed).to eq(actual)
+      end
+
+      context "when config is set to check_only" do
+        it "raises ClientNotInstalled" do
+          expect do
+            klass.check!(target, true)
+          end.to raise_error(ChefApply::MinimumChefVersion::ClientNotInstalled)
+        end
+      end
+    end
+
+    [:windows, :linux].each do |os|
+      context "on #{os}" do
+        let(:base_os) { os }
+        [13, 14].each do |major_version|
+          context "when chef is already installed at the correct minimum Chef #{major_version} version" do
+            let(:version) { ChefApply::MinimumChefVersion::CONSTRAINTS[os][major_version] }
+            it "should return :minimum_version_met" do
+              actual = klass.check!(target, false)
+              expect(:minimum_version_met).to eq(actual)
+            end
+          end
+        end
+      end
+    end
+
+    installed_expected = {
+      windows: {
+        Gem::Version.new("12.1.1") => ChefApply::MinimumChefVersion::Client13Outdated,
+        Gem::Version.new("13.9.0") => ChefApply::MinimumChefVersion::Client13Outdated,
+        Gem::Version.new("14.3.37") => ChefApply::MinimumChefVersion::Client14Outdated,
+      },
+      linux: {
+        Gem::Version.new("12.1.1") => ChefApply::MinimumChefVersion::Client13Outdated,
+        Gem::Version.new("13.9.0") => ChefApply::MinimumChefVersion::Client13Outdated,
+        Gem::Version.new("14.1.0") => ChefApply::MinimumChefVersion::Client14Outdated,
+      }
+    }
+    [:windows, :linux].each do |os|
+      context "on #{os}" do
+        let(:base_os) { os }
+        installed_expected[os].each do |installed, expected|
+          context "when chef is already installed on target at version #{installed}" do
+            let(:version) { installed }
+            it "notifies of failure and takes no further action" do
+              expect { klass.check!(target, false) }.to raise_error(expected)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Fixes https://github.com/chef/chef-apply/issues/22

Chef suffered from a variety of errors when trying to run with Tarball
support. On Windows the URI file unpacker fails with a GZip error. If we
specify relative paths on Chef 13 it thinks the files are at the root of
the directory.

We fix these by specifying full paths, and setting the minimum chef
versions to ones that include support for:
https://github.com/chef/chef/pull/7522
https://github.com/chef/chef/pull/7523

*NOTE*
Astute observers will notice that the minimum Chef 14 version on Windows (`14.4.22`) is not yet released. This is planned for next week. I did this because it kept the logic simpler and more straightforward. Otherwise I would have to make another PR next week to fix some complicated logic I added today. Windows is such a small target base, and it already does not work, so this is a temporary bug that will automatically be fixed when Chef 14.4 is released next week.

### Issues Resolved

Fixes https://github.com/chef/chef-apply/issues/22
SHACK-290

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change

Signed-off-by: tyler-ball <tball@chef.io>