### PR TITLE
Make pry breakpoints work with MultiSpinner

### DIFF
--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -35,6 +35,7 @@ require "chef_apply/target_resolver"
 require "chef_apply/telemeter"
 require "chef_apply/ui/error_printer"
 require "chef_apply/ui/terminal"
+require "chef_apply/ui/terminal/job"
 
 module ChefApply
   class CLI
@@ -130,12 +131,16 @@ module ChefApply
     end
 
     def render_cookbook_setup(arguments)
-      UI::Terminal.render_job(TS.generate_temp_cookbook.generating) do |reporter|
+      # TODO update Job so that it doesn't require prefix and host. As a data container,
+      # should these attributes even be required?
+      job = UI::Terminal::Job.new("", nil) do |reporter|
         @temp_cookbook = generate_temp_cookbook(arguments, reporter)
       end
-      UI::Terminal.render_job(TS.generate_temp_cookbook.generating) do |reporter|
+      UI::Terminal.render_job("...", job)
+      job = UI::Terminal::Job.new("", nil) do |reporter|
         @archive_file_location = generate_local_policy(reporter)
       end
+      UI::Terminal.render_job("...", job)
     end
 
     def render_converge(target_hosts)

--- a/lib/chef_apply/config.rb
+++ b/lib/chef_apply/config.rb
@@ -130,7 +130,7 @@ module ChefApply
     end
 
     config_context :dev do
-      default(:spinner, "TTY::Spinner")
+      default(:spinner, true)
     end
 
     config_context :chef do

--- a/lib/chef_apply/ui/plain_text_element.rb
+++ b/lib/chef_apply/ui/plain_text_element.rb
@@ -29,7 +29,7 @@ module ChefApply
       end
 
       def update(params)
-        # SOme of this is particular to our usage -
+        # Some of this is particular to our usage -
         # prefix does not cause a text update, but does
         # change the prefix for future messages.
         if params.has_key?(:prefix)
@@ -69,6 +69,9 @@ module ChefApply
       def success
         @succ = true
         @err = false
+      end
+
+      def auto_spin
       end
     end
   end

--- a/lib/chef_apply/ui/plain_text_header.rb
+++ b/lib/chef_apply/ui/plain_text_header.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require "thread"
+require "chef_apply/ui/plain_text_element"
+
+module ChefApply
+  module UI
+    class PlainTextHeader
+      def initialize(format, opts)
+        @format = format
+        @output = opts[:output]
+        @children = {}
+        @threads = []
+      end
+
+      def register(child_format, child_opts, &block)
+        child_opts[:output] = @output
+        child = PlainTextElement.new(child_format, child_opts)
+        @children[child] = block
+      end
+
+      def auto_spin
+        msg = @format.gsub(/:spinner/, " HEADER ")
+        @output.puts(msg)
+        @children.each do |child, block|
+          @threads << Thread.new { block.call(child) }
+        end
+        @threads.each { |thr| thr.join }
+      end
+    end
+  end
+end

--- a/lib/chef_apply/ui/terminal/job.rb
+++ b/lib/chef_apply/ui/terminal/job.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefApply
+  module UI
+    class Terminal
+      class Job
+        attr_reader :proc, :prefix, :target_host, :exception
+        def initialize(prefix, target_host, &block)
+          @proc = block
+          @prefix = prefix
+          @target_host = target_host
+          @error = nil
+        end
+
+        def run(reporter)
+          @proc.call(reporter)
+        rescue => e
+          reporter.error(e.to_s)
+          @exception = e
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -293,13 +293,19 @@ RSpec.describe ChefApply::CLI do
     let(:temp_cookbook) { double(ChefApply::TempCookbook) }
     let(:archive_file_location) { "/path/to/archive" }
     let(:args) { [] }
-    before do
-      allow(ChefApply::UI::Terminal).to receive(:render_job).and_yield(reporter)
-    end
+    # before do
+    #   allow(ChefApply::UI::Terminal).to receive(:render_job).and_yield(reporter)
+    # end
 
     it "generates the cookbook and local policy" do
+      expect(ChefApply::UI::Terminal).to receive(:render_job) do |initial_msg, job|
+        job.run(reporter)
+      end
       expect(subject).to receive(:generate_temp_cookbook)
         .with(args, reporter).and_return temp_cookbook
+      expect(ChefApply::UI::Terminal).to receive(:render_job) do |initial_msg, job|
+        job.run(reporter)
+      end
       expect(subject).to receive(:generate_local_policy)
         .with(reporter).and_return archive_file_location
       subject.render_cookbook_setup(args)

--- a/spec/unit/ui/terminal_spec.rb
+++ b/spec/unit/ui/terminal_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe ChefApply::UI::Terminal do
   context "#render_job" do
     it "executes the provided block" do
       @ran = false
-      Terminal.render_job("a message") { |reporter| @ran = true }
+      job = Terminal::Job.new("prefix", nil) do
+        @ran = true
+      end
+      Terminal.render_job("a message", job)
       expect(@ran).to eq true
     end
   end


### PR DESCRIPTION
### Description

1) Pulled Job class out into its own file since we are referencing it more
2) Change dev spinner config value to true/false instead of specifying class names. This allow us to manage classes internally and developers only need to specify 'do I want spinners in my output or not'
3) Introduced a PlainTextHeader class. This allows us to turn the multi-spinner and regular spinner into just single line outputs so 'pry' starts working in local development again

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change

Signed-off-by: tyler-ball <tball@chef.io>