### PR TITLE
[SHACK-359] Prevent chef-run from executing in the context of ChefDK.

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -149,6 +149,17 @@ cli:
       Please verify that the configuration file is correct. If the
       problem continues, contact beta@chef.io for further assistance.
 
+    unsupported_installation: |
+
+      Use of chef-run within ChefDK is not supported.
+
+      Chef Workstation is the successor to the ChefDK, and contains the
+      same components including a supported chef-run.
+
+      Download the latest here:
+
+      https://downloads.chef.io/chef-workstation/stable
+
   version:
     description: Show the current version of Chef Run.
     show: "chef-run: %1"


### PR DESCRIPTION
chef-run is currently built as part of ChefDK for build dependency
reasons, however using it under DK is not supported.

When the chef-run command is run from within the ChefDK install,
we will now show an error directing the operator to download
Chef Workstation for access to chef-run.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
