### PR TITLE
Correct error 'bash: - invalid option'

### DIFF
--- a/lib/chef_apply/action/base.rb
+++ b/lib/chef_apply/action/base.rb
@@ -60,22 +60,17 @@ module ChefApply
           windows: "%TEMP%",
           other: "$TMPDIR",
         },
-        mkdir: {
-          windows: "New-Item -ItemType Directory -Force -Path ",
-          other: "mkdir -p ",
-        },
-        # TODO this is duplicating some stuff in the install_chef folder
-        # TODO maybe we start to break these out into actual functions, so
-        # we don't have to try and make really long one-liners
-        mktemp: {
-          windows: "$parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); $tmp = New-Item -ItemType Directory -Path (Join-Path $parent $name); $tmp.FullName",
-          other: "bash -c 'd=$(mktemp -d -p${TMPDIR:-/tmp} chef_XXXXXX); chmod 777 $d; echo $d'"
-        },
         delete_folder: {
           windows: "Remove-Item -Recurse -Force –Path",
           other: "rm -rf",
         }
       }
+
+      # TODO - I'd like to consider PATH_MAPPING in action::base
+      #        to platform subclasses/mixins for target_host.  This way our 'target host'
+      #        which reprsents a node, the data and actions we can perform on it
+      #        knows how to `read_chef_report`, `mkdir`, etc.
+      #        -mp 2018-10-17
 
       PATH_MAPPING.keys.each do |m|
         define_method(m) { PATH_MAPPING[m][family] }

--- a/lib/chef_apply/action/install_chef/linux.rb
+++ b/lib/chef_apply/action/install_chef/linux.rb
@@ -30,8 +30,7 @@ module ChefApply::Action::InstallChef
 
     def setup_remote_temp_path
       installer_dir = "/tmp/chef-installer"
-      target_host.run_command!("mkdir -p #{installer_dir}")
-      target_host.run_command!("chmod 777 #{installer_dir}")
+      target_host.mkdir(installer_dir)
       installer_dir
     end
   end

--- a/spec/unit/action/base_spec.rb
+++ b/spec/unit/action/base_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ChefApply::Action::Base do
   end
 
   shared_examples "check path fetching" do
-    [:chef_client, :cache_path, :read_chef_report, :delete_chef_report, :tempdir, :mktemp, :delete_folder].each do |path|
+    [:chef_client, :cache_path, :read_chef_report, :delete_chef_report, :tempdir, :delete_folder].each do |path|
       it "correctly returns path #{path}" do
         expect(action.send(path)).to be_a(String)
       end

--- a/spec/unit/action/converge_target_spec.rb
+++ b/spec/unit/action/converge_target_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe ChefApply::Action::ConvergeTarget do
       let!(:cert2) { FileUtils.touch(File.join(certs_dir, "2.pem"))[0] }
 
       it "uploads the local certs" do
-        expect(target_host).to receive(:run_command).with("#{subject.mkdir} #{remote_tcd}", true)
+        expect(target_host).to receive(:mkdir).with(remote_tcd)
         expect(target_host).to receive(:upload_file).with(cert1, File.join(remote_tcd, File.basename(cert1)))
         expect(target_host).to receive(:upload_file).with(cert2, File.join(remote_tcd, File.basename(cert2)))
         subject.upload_trusted_certs(remote_folder)
@@ -254,9 +254,9 @@ RSpec.describe ChefApply::Action::ConvergeTarget do
     let(:remote_archive) { File.join(remote_folder, File.basename(archive)) }
     let(:remote_config) { "#{remote_folder}/workstation.rb" }
     let(:remote_handler) { "#{remote_folder}/reporter.rb" }
-    let(:tmpdir) { double("tmpdir", exit_status: 0, stdout: remote_folder) }
+    let(:tmpdir) { remote_folder }
     before do
-      expect(target_host).to receive(:run_command!).with(subject.mktemp, true).and_return(tmpdir)
+      expect(target_host).to receive(:mktemp).and_return(tmpdir)
     end
     let(:result) { double("command result", exit_status: 0, stdout: "") }
 


### PR DESCRIPTION
### Description

This was added to work around permissions issues, where
a newly created directory would be created with sudo,
then upload over SCP would fail because it used the connecting user
who had no access to that directory.

Setting ownership is now encapsulated in TargetHost#mkdir and
TargetHost#mktemp, so that callers can mkdir then use it for upload
without worrying about platform-specific permissions behaviors.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
### Issues

This addresses https://github.com/chef/chef-apply/issues/40


### Check List

- [x] New functionality includes tests
- [x] All (existing) tests pass
- [x] New tests for: 
  - [x] RemoteTarget#mktemp
  - [x] RemoteTarget#mkdir
  - [x] RemoteTarget#chown
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change - partially, additional validation to ensure that this doesn't  break the automate integration w/ trusted certs provided from host. 
