### PR TITLE
Expand user supplied config paths

### DIFF
--- a/lib/chef_apply/config.rb
+++ b/lib/chef_apply/config.rb
@@ -110,13 +110,17 @@ module ChefApply
 
     config_context :log do
       default(:level, "warn")
-      default(:location, File.join(WS_BASE_PATH, "logs/default.log"))
+      configurable(:location)
+        .defaults_to(File.join(WS_BASE_PATH, "logs/default.log"))
+        .writes_value { |p| File.expand_path(p) }
       # set the log level for the target host's chef-client run
       default(:target_level, nil)
     end
 
     config_context :cache do
-      default(:path, File.join(WS_BASE_PATH, "cache"))
+      configurable(:path)
+        .defaults_to(File.join(WS_BASE_PATH, "cache"))
+        .writes_value { |p| File.expand_path(p) }
     end
 
     config_context :connection do


### PR DESCRIPTION
### Description

If we do not do this the user could specify '~' in the path and we
try to interpret that as a real location

### Issues Resolved

Reported in slack

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
