### PR TITLE
Revert https://github.com/chef/chef-apply/pull/96

### DIFF
--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -129,7 +129,7 @@ module ChefApply
     end
 
     def start_telemeter_upload
-      ChefApply::Telemeter::Sender.start_upload_thread() if ChefApply::Telemeter.enabled?
+      ChefApply::Telemeter::Sender.start_upload_thread()
     end
 
     def setup_workstation_user_directories

--- a/spec/unit/startup_spec.rb
+++ b/spec/unit/startup_spec.rb
@@ -203,14 +203,6 @@ RSpec.describe ChefApply::Startup do
       expect(ChefApply::Telemeter::Sender).to receive(:start_upload_thread)
       subject.start_telemeter_upload
     end
-
-    context "when telemetry is disabled" do
-      it "does not launch telemetry upload" do
-        expect(ChefApply::Telemeter).to receive(:enabled?).and_return(false)
-        expect(ChefApply::Telemeter::Sender).to_not receive(:start_upload_thread)
-        subject.start_telemeter_upload
-      end
-    end
   end
 
   describe "setup_workstation_user_directories" do


### PR DESCRIPTION
## Description
I mistakenly thought that telemetry data would be sent even if telemetry
is disabled. But there is already a check in the `run` method of
sender.rb that prevents this. Reverting the above PR because it is
unnecessary and prevents cleaning up the telemetry data files (which
happens regardless of whether they are sent successfully).

## Related Issue
Reverts https://github.com/chef/chef-apply/pull/96

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
