### PR TITLE
Pinning Train to prevent pulling in train-winrm updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       pastel
       r18n-desktop
       toml-rb
-      train
+      train (< 3.0)
       tty-spinner
 
 GEM
@@ -310,7 +310,7 @@ GEM
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
-    train (3.0.1)
+    train (2.1.19)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
       azure_mgmt_resources (~> 0.15)
@@ -322,6 +322,8 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
     train-core (2.1.19)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)

--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -48,7 +48,9 @@ Gem::Specification.new do |spec|
                                      # localization gem...
   spec.add_dependency "toml-rb" # This isn't ideal because mixlib-config uses 'tomlrb'
                                 # but that library does not support a dumper
-  spec.add_dependency "train" # remote connection management over ssh, winrm
+  # Train 3.x introduces changes to train-winrm that we are not ready to consume across
+  # the entire Chef Workstation ecosystem
+  spec.add_dependency "train", "< 3.0" # remote connection management over ssh, winrm
   spec.add_dependency "pastel" # A color library
   spec.add_dependency "tty-spinner" # Pretty output for status updates in the CLI
   spec.add_dependency "chef", ">= 15.0" # Needed to load cookbooks


### PR DESCRIPTION
train 3.x conflicts (via train-winrm) with the rest of our Workstation
ecosystem, so need to pin below that for now.