### PR TITLE
We are updating to Train 3.x across the Workstation/DK, ensure this gets bumped

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,8 @@ PATH
       pastel
       r18n-desktop
       toml-rb
-      train (< 3.0)
+      train (~> 3.0)
+      train-winrm
       tty-spinner
 
 GEM
@@ -92,7 +93,7 @@ GEM
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
-    chefstyle (0.13.2)
+    chefstyle (0.13.3)
       rubocop (= 0.72.0)
     citrus (3.0.2)
     coderay (1.1.2)
@@ -231,7 +232,7 @@ GEM
     os (1.0.1)
     paint (1.0.1)
     parallel (1.17.0)
-    parser (2.6.3.0)
+    parser (2.6.4.0)
       ast (~> 2.4.0)
     pastel (0.7.3)
       equatable (~> 0.6)
@@ -310,7 +311,7 @@ GEM
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
-    train (2.1.19)
+    train (3.0.3)
       azure_graph_rbac (~> 0.16)
       azure_mgmt_key_vault (~> 0.17)
       azure_mgmt_resources (~> 0.15)
@@ -322,13 +323,14 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
-      winrm (~> 2.0)
-      winrm-fs (~> 1.0)
     train-core (2.1.19)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+    train-winrm (0.2.3)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
     tty-box (0.4.1)

--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -48,9 +48,8 @@ Gem::Specification.new do |spec|
                                      # localization gem...
   spec.add_dependency "toml-rb" # This isn't ideal because mixlib-config uses 'tomlrb'
                                 # but that library does not support a dumper
-  # Train 3.x introduces changes to train-winrm that we are not ready to consume across
-  # the entire Chef Workstation ecosystem
-  spec.add_dependency "train", "< 3.0" # remote connection management over ssh, winrm
+  spec.add_dependency "train", "~> 3.0" # remote connection management over ssh, winrm
+  spec.add_dependency "train-winrm" # winrm transports were pulled out into this plugin
   spec.add_dependency "pastel" # A color library
   spec.add_dependency "tty-spinner" # Pretty output for status updates in the CLI
   spec.add_dependency "chef", ">= 15.0" # Needed to load cookbooks


### PR DESCRIPTION
## Description
`train-core` stays at 2.1.19 for now because that is a transitive dep of chef. Once we update chef to >= 15.3 `train-core` will update to >= 3.0. Since they are split out as `train` vs `train-core` there is no conflict, and `train-core` is just a subset of `train`.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
