### PR TITLE
Avoid running bundle update on version bump

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -7,6 +7,3 @@
 set -evx
 
 sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/"  lib/chef_apply/version.rb
-
-# Ensure our Gemfile.lock reflects the new version
-bundle update chef-apply


### PR DESCRIPTION
## Description

Since we removed the `Gemfile.lock` we no longer need to run a bundle
update on version bumps.

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
