### PR TITLE
Update testing to use our latest containers

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -39,12 +39,12 @@ merge_actions:
   - built_in:build_gem:
       only_if: built_in:bump_version
 
-promote:
-  actions:
-    - built_in:rollover_changelog
-    - built_in:publish_rubygems
-
 pipelines:
   - verify:
       description: Pull Request validation tests
       public: true
+
+promote:
+  actions:
+    - built_in:rollover_changelog
+    - built_in:publish_rubygems

--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# This script runs a passed in command, but first setups up the bundler caching on the repo
+
+set -e
+
+export USER="root"
+
+# make sure we have the aws cli
+apt-get update -y
+apt-get install awscli -y
+
+# grab the s3 bundler if it's there and use it for all operations in bundler
+echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz"
+aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" bundle.tar.gz || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
+aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
+
+echo "Restoring the bundle cache archive to vendor/bundle"
+if [ -f bundle.tar.gz ]; then
+  tar -xzf bundle.tar.gz
+fi
+bundle config --local path vendor/bundle
+
+bundle install --jobs=7 --retry=3
+bundle exec $1
+
+if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
+  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
+    echo "Bundled gems have not changed. Skipping upload to s3"
+    exit
+  fi
+fi
+
+echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
+shasum -a 256 vendor/bundle > bundle.sha256
+
+echo "Creating the tar.gz to of the vendor/bundle directory to ship to s3"
+tar -czf bundle.tar.gz vendor/
+
+echo "Uploading the tar.gz of the vendor/bundle directory to s3"
+aws s3 cp bundle.tar.gz "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
+
+echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
+aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -7,3 +7,6 @@
 set -evx
 
 sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/"  lib/chef_apply/version.rb
+
+# Once Expeditor finshes executing this script, it will commit the changes and push
+# the commit as a new tag corresponding to the value in the VERSION file.

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,29 +2,27 @@ steps:
 
 - label: lint-chefstyle
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake style
+    - .expeditor/run_linux_tests.sh "rake style"
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-buster
 
 - label: run-specs-ruby-2.5
   command:
-    - asdf local ruby 2.5.5
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake spec
+    - .expeditor/run_linux_tests.sh "rake spec"
   expeditor:
     executor:
       docker:
+        image: ruby:2.5-buster
 
 - label: run-specs-ruby-2.6
   command:
-    - asdf local ruby 2.6.3
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake spec
+    - .expeditor/run_linux_tests.sh "rake spec"
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-buster
 
 - label: run-specs-windows
   command:


### PR DESCRIPTION
Use the upstream containers and the s3 caching script. This way we don't
have to update this every time a new ruby comes out and it'll be a lot
faster to run the PR tests

Fixes #110 

Signed-off-by: Tim Smith <tsmith@chef.io>