### PR TITLE
Slim the gem down by removing specs + switch from train to train-core

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -2,43 +2,52 @@
 #
 # This script runs a passed in command, but first setups up the bundler caching on the repo
 
-set -e
+set -ue
 
 export USER="root"
 
-# make sure we have the aws cli
+echo "--- dependencies"
+export LANG=C.UTF-8 LANGUAGE=C.UTF-8
+S3_URL="s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}"
+
+pull_s3_file() {
+    aws s3 cp "${S3_URL}/$1" "$1" || echo "Could not pull $1 from S3"
+}
+
+push_s3_file() {
+    if [ -f "$1" ]; then
+        aws s3 cp "$1" "${S3_URL}/$1" || echo "Could not push $1 to S3 for caching."
+    fi
+}
+
 apt-get update -y
 apt-get install awscli -y
 
-# grab the s3 bundler if it's there and use it for all operations in bundler
-echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz"
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" bundle.tar.gz || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
+echo "--- bundle install"
+pull_s3_file "bundle.tar.gz"
+pull_s3_file "bundle.sha256"
 
-echo "Restoring the bundle cache archive to vendor/bundle"
 if [ -f bundle.tar.gz ]; then
   tar -xzf bundle.tar.gz
 fi
-bundle config --local path vendor/bundle
 
-bundle install --jobs=7 --retry=3
-bundle exec $1
-
-if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
-  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
-    echo "Bundled gems have not changed. Skipping upload to s3"
-    exit
-  fi
+if [ -n "${RESET_BUNDLE_CACHE:-}" ]; then
+    rm bundle.sha256
 fi
 
-echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
-shasum -a 256 vendor/bundle > bundle.sha256
+bundle config --local path vendor/bundle
+bundle install --jobs=7 --retry=3
 
-echo "Creating the tar.gz to of the vendor/bundle directory to ship to s3"
-tar -czf bundle.tar.gz vendor/
+echo "--- bundle cache"
+if test -f bundle.sha256 && shasum --check bundle.sha256 --status; then
+    echo "Bundled gems have not changed. Skipping upload to s3"
+else
+    echo "Bundled gems have changed. Uploading to s3"
+    shasum -a 256 Gemfile.lock > bundle.sha256
+    tar -czf bundle.tar.gz vendor/
+    push_s3_file bundle.tar.gz
+    push_s3_file bundle.sha256
+fi
 
-echo "Uploading the tar.gz of the vendor/bundle directory to s3"
-aws s3 cp bundle.tar.gz "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
-
-echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
-aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
+echo "+++ bundle exec task"
+bundle exec $1

--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -31,10 +31,10 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.files = %w{Rakefile LICENSE README.md warning.txt} +
+  spec.files = %w{Rakefile LICENSE warning.txt} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
     Dir.glob("*.gemspec") +
-    Dir.glob("{bin,i18n,lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+    Dir.glob("{bin,i18n,lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
                                      # localization gem...
   spec.add_dependency "toml-rb" # This isn't ideal because mixlib-config uses 'tomlrb'
                                 # but that library does not support a dumper
-  spec.add_dependency "train", "~> 3.0" # remote connection management over ssh, winrm
+  spec.add_dependency "train-core", "~> 3.0" # remote connection management over ssh, winrm
   spec.add_dependency "train-winrm" # winrm transports were pulled out into this plugin
   spec.add_dependency "pastel" # A color library
   spec.add_dependency "tty-spinner" # Pretty output for status updates in the CLI


### PR DESCRIPTION
Also use the new test script better caches the gems during the run.

Remove the specs and the readme from the gem artifact to reduce the size
of the install artifact. This drops our Workstation install size by 51
files and 238k on disk.

I changed the train dep from train to train-core since we also dep on
chef 15+ which includes train-core as a dep. There's no reason to
install both versions of train in CI for testing. In the workstation
package we'll end up installing both, but this is *more* correct. We
don't need all the azure/gce/ec2 deps just to test chef-apply since it
doesn't use any of that.

Signed-off-by: Tim Smith <tsmith@chef.io>