### PR TITLE
Disable strict config checking

### DIFF
--- a/chef-apply.gemspec
+++ b/chef-apply.gemspec
@@ -39,10 +39,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mixlib-cli"    # Provides argument handling DSL for CLI applications
-  spec.add_dependency "mixlib-config" # shared chef configuration library that
-                                      # simplifies managing a configuration file
-  spec.add_dependency "mixlib-log"    # Basis for our traditional logger
+  spec.add_dependency "mixlib-cli" # Provides argument handling DSL for CLI applications
+  spec.add_dependency "mixlib-config", ">= 3.0.5"  # shared chef configuration library that
+                                                   # simplifies managing a configuration file
+  spec.add_dependency "mixlib-log" # Basis for our traditional logger
   spec.add_dependency "mixlib-install" # URL resolver + install tool for chef products
   spec.add_dependency "r18n-desktop" # easy path to message text management via
                                      # localization gem...

--- a/lib/chef_apply/config.rb
+++ b/lib/chef_apply/config.rb
@@ -97,7 +97,12 @@ module ChefApply
 
     extend Mixlib::Config
 
-    config_strict_mode true
+    # This configuration is shared among many components.
+    # While enabling strict mode can provide a better experience
+    # around validated config entries, chef-apply won't know about
+    # config items that it doesn't own, and we don't want it to
+    # fail to start when that happens.
+    config_strict_mode false
 
     # When working on Chef Apply itself,
     # developers should set telemetry.dev to true


### PR DESCRIPTION
Strict mode was originally enabled to provide a better UX
around validated configuration entries, but the scope of chef-workstation
configuration has expanded beyond this single tool.

Disabling this allows us to avoid adding config support to chef-apply
every time we add new config keys for chef workstation app,
chef command line, chef-analyze, etc.  

The trade-off is that
we will not be able to detect when the operator has a bad configuration
that includes keys that are genuinely invalid.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
