### PR TITLE
Add missing error CHEFVAL001

### DIFF
--- a/i18n/errors/en.yml
+++ b/i18n/errors/en.yml
@@ -257,6 +257,14 @@ errors:
       %1
 
   # CLI argument validation errors
+  #
+  CHEFVAL001:
+    display: { decorations: false }
+    text: |
+      The key file you specified does not exist or can't be read.
+
+      You provided '%1'.
+
   CHEFVAL002:
     display: { decorations: false }
     text: |

--- a/lib/chef_apply/cli/options.rb
+++ b/lib/chef_apply/cli/options.rb
@@ -64,7 +64,7 @@ module ChefApply
           description: T.identity_file,
           proc: (Proc.new do |paths|
             path = paths
-            unless File.exist?(path)
+            unless File.readable?(path)
               raise OptionValidationError.new("CHEFVAL001", self, path)
             end
 

--- a/lib/chef_apply/cli/options.rb
+++ b/lib/chef_apply/cli/options.rb
@@ -65,7 +65,7 @@ module ChefApply
           proc: (Proc.new do |paths|
             path = paths
             unless File.readable?(path)
-              raise OptionValidationError.new("CHEFVAL001", self, path)
+              raise OptionValidationError.new("CHEFVAL001", nil, path)
             end
 
             path

--- a/lib/chef_apply/telemeter.rb
+++ b/lib/chef_apply/telemeter.rb
@@ -36,5 +36,9 @@ module ChefApply
       end
       Chef::Telemeter.timed_capture(:action, { action: action.name, target: target_data }, &block)
     end
+
+    def self.capture(name, data = {}, options = {})
+      Chef::Telemeter.capture(name, data, options)
+    end
   end
 end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe ChefApply::CLI do
       end
     end
 
+    context "when an unreadable or missing identity file flag is provided" do
+      let(:argv) { %w{arg1 -i /path/that/is/bad.pem } }
+      it "reports CHEFVAL001" do
+        expect(File).to receive(:readable?).with("/path/that/is/bad.pem").and_return(false)
+        expect { subject.perform_run }.to raise_error do |e|
+          expect(e.contained_exception.id).to eq "CHEFVAL001"
+        end
+      end
+    end
+
     context "when help flags are passed" do
       %w{-h --help}.each do |flag|
         context flag do
@@ -153,6 +163,7 @@ RSpec.describe ChefApply::CLI do
           subject.perform_run
         end
       end
+
     end
   end
 


### PR DESCRIPTION
Fixes #118

This also corrects an error introduced with the shift to the new telemetry library, where our error handling would cause a call to ChefApply::Telemeter::capture, which does not exist. 

Finally, it changes CHEFVAL001 (unreadable key) behavior so that it does not try to print usgae - showing usage when we already have a clear error and path for the operator to correct it just muddies the output. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
