### PR TITLE
Fix some mismatches in config values we send to the telemetry gem

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -8,14 +8,6 @@ steps:
       docker:
         image: ruby:2.6-buster
 
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh "rake spec"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh "rake spec"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -24,6 +24,14 @@ steps:
       docker:
         image: ruby:2.6-buster
 
+- label: run-specs-ruby-2.7
+  command:
+    - .expeditor/run_linux_tests.sh "rake spec"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster
+
 - label: run-specs-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -25,7 +25,7 @@ cli:
     %1:
 
     [telemetry]
-    enable=false
+    enabled=false
 
     For more information about what we data gather and additional opt-out
     options, visit https://chef.sh/docs/chef-workstation/privacy/

--- a/lib/chef_apply/config.rb
+++ b/lib/chef_apply/config.rb
@@ -109,8 +109,8 @@ module ChefApply
     # in their local configuration to ensure that dev usage
     # doesn't skew customer telemetry.
     config_context :telemetry do
-      default(:dev, false)
-      default(:enable, true)
+      default(:dev_mode, false)
+      default(:enabled, true)
     end
 
     config_context :log do

--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -132,7 +132,7 @@ module ChefApply
     def start_telemeter_upload
       cfg = {
         enabled: Config.telemetry[:enabled],
-        dev: Config.telemetry[:dev_mode],
+        dev_mode: Config.telemetry[:dev_mode],
         payload_dir: Config.telemetry_path,
         installation_identifier_file: Config.telemetry_installation_identifier_file,
         session_file: Config.telemetry_session_file,

--- a/spec/unit/action/install_chef_spec.rb
+++ b/spec/unit/action/install_chef_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ChefApply::Action::InstallChef do
     }
   end
   let(:target_host) do
-    ChefApply::TargetHost.mock_instance("mock://user1:password1@localhost", mock_opts)
+    ChefApply::TargetHost.mock_instance("mock://user1:password1@localhost", **mock_opts)
   end
 
   let(:reporter) do


### PR DESCRIPTION
## Description
Also adds testing for Ruby 2.7 since Workstation is releasing with that
soon and fixes a warning discovered in 2.7.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
