### PR TITLE
Add enforce_license license parameter to cli startup

### DIFF
--- a/bin/chef-run
+++ b/bin/chef-run
@@ -20,4 +20,4 @@ require "chef_apply/startup"
 
 # Perform initialization tasks then hand off control to
 # CLI to run the command.
-ChefApply::Startup.new(ARGV).run
+ChefApply::Startup.new(ARGV).run(enforce_license: true)

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -63,14 +63,14 @@ module ChefApply
       super()
     end
 
-    def run
+    def run(enforce_license: false)
       # Perform a timing and capture of the run. Individual methods and actions may perform
       # nested Chef::Telemeter.timed_*_capture or Chef::Telemeter.capture calls in their operation, and
       # they will be captured in the same telemetry session.
 
       Chef::Telemeter.timed_run_capture([:redacted]) do
         begin
-          perform_run
+          perform_run(enforce_license: enforce_license)
         rescue Exception => e
           @rc = handle_run_error(e)
         end
@@ -100,14 +100,14 @@ module ChefApply
       end
     end
 
-    def perform_run
+    def perform_run(enforce_license: false)
       parse_options(@argv)
       if @argv.empty? || parsed_options[:help]
         show_help
       elsif parsed_options[:version]
         show_version
       else
-        check_license_acceptance
+        check_license_acceptance if enforce_license
         validate_params(cli_arguments)
         target_hosts = resolve_targets(cli_arguments.shift, parsed_options)
         render_cookbook_setup(cli_arguments)

--- a/lib/chef_apply/startup.rb
+++ b/lib/chef_apply/startup.rb
@@ -33,7 +33,7 @@ module ChefApply
       init_terminal
     end
 
-    def run
+    def run(enforce_license: false)
       # This component is not supported in ChefDK; an exception will be raised
       # if running in that context.
       verify_not_in_chefdk
@@ -62,7 +62,7 @@ module ChefApply
       start_telemeter_upload
 
       # Launch the actual Chef Apply behavior
-      start_chef_apply
+      start_chef_apply(enforce_license: enforce_license)
 
     # NOTE: Because these exceptions occur outside of the
     #       CLI handling, they won't be tracked in telemtry.
@@ -194,9 +194,9 @@ module ChefApply
       Chef::Log.level = ChefApply::Log.level
     end
 
-    def start_chef_apply
+    def start_chef_apply(enforce_license: false)
       require_relative "cli"
-      ChefApply::CLI.new(@argv).run
+      ChefApply::CLI.new(@argv).run(enforce_license: enforce_license)
     end
 
     private

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -41,7 +41,7 @@ FileUtils.touch(conf) unless File.exist?(conf)
 # usage:
 #   expect {run_with_cli("blah")}.to output("blah").to_stdout
 def run_cli_with(args)
-  ChefApply::Startup.new(args.split(" ")).run
+  ChefApply::Startup.new(args.split(" ")).run(enforce_license: true)
 rescue SystemExit
 end
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -160,7 +160,16 @@ RSpec.describe ChefApply::CLI do
           expect(subject).to receive(:resolve_targets).and_return target_hosts
           expect(subject).to receive(:render_cookbook_setup)
           expect(subject).to receive(:render_converge).with(target_hosts)
-          subject.perform_run
+          subject.perform_run(enforce_license: true)
+        end
+        it "not check license" do
+          expect(subject).to receive(:parse_options)
+          expect(subject).to_not receive(:check_license_acceptance)
+          expect(subject).to receive(:validate_params)
+          expect(subject).to receive(:resolve_targets).and_return target_hosts
+          expect(subject).to receive(:render_cookbook_setup)
+          expect(subject).to receive(:render_converge).with(target_hosts)
+          subject.perform_run(enforce_license: false)
         end
       end
 


### PR DESCRIPTION
This implements a similar feature that other check binaries have such as
chef-client to use a parameter in the CLI startup to toggle license enforcement.
This is useful for other Chef distributions (such as Cinc) to more easily allow
running this without verifying the license with minimal patching.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Description

I'm not thrilled with how I implemented this since I had to follow down the chain of various methods. I feel like there is a better way to do this, so please let me know.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
