### PR TITLE
Allow passing symbols for ad-hoc resource property values 

### DIFF
--- a/lib/chef_apply/cli/validation.rb
+++ b/lib/chef_apply/cli/validation.rb
@@ -76,6 +76,8 @@ module ChefApply
           value.to_i
         when /^\d+\.\d*$/, /^\d*\.\d+$/
           value.to_f
+        when /^[:].+$/
+          value.split(":").last.to_sym
         when /true/i
           true
         when /false/i

--- a/spec/unit/cli/validation_spec.rb
+++ b/spec/unit/cli/validation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ChefApply::CLI::Validation do
   end
   describe "#properties_from_string" do
     it "parses properties into a hash" do
-      provided = %w{key1=value key2=1 key3=true key4=FaLsE key5=0777 key6=https://some.website key7=num1and2digit key_8=underscore key9=127.0.0.1 key10=1. key11=1.1}
+      provided = %w{key1=value key2=1 key3=true key4=FaLsE key5=0777 key6=https://some.website key7=num1and2digit key_8=underscore key9=127.0.0.1 key10=1. key11=1.1 key12=:symbol}
       expected = {
         "key1" => "value",
         "key2" => 1,
@@ -73,6 +73,7 @@ RSpec.describe ChefApply::CLI::Validation do
         "key9" => "127.0.0.1",
         "key10" => 1.0,
         "key11" => 1.1,
+        "key12" => :symbol,
       }
       expect(subject.properties_from_string(provided)).to eq(expected)
     end


### PR DESCRIPTION
<!--- Handled the conversion of strings into symbols for property values. -->

## Description
<!--- The problem here was Many resources use symbols for property values and don't auto-convert strings.
Now, we have introduced a logic to convert string to symbols-->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
