### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -28,7 +28,8 @@ steps:
 
 - label: run-specs-windows
   command:
-    - bundle config set --local without docs debug path vendor/bundle
+    - bundle config set --local without docs debug
+    - bundle config set --local path vendor/bundle
     - bundle install --jobs=7 --retry=3
     - bundle exec rake spec
   expeditor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -28,7 +28,7 @@ steps:
 
 - label: run-specs-windows
   command:
-    - bundle config set without docs debug --local path vendor/bundle
+    - bundle config set --local without docs debug path vendor/bundle
     - bundle install --jobs=7 --retry=3
     - bundle exec rake spec
   expeditor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -28,8 +28,8 @@ steps:
 
 - label: run-specs-windows
   command:
-    - bundle config --local path vendor/bundle
-    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle config set without docs debug --local path vendor/bundle
+    - bundle install --jobs=7 --retry=3
     - bundle exec rake spec
   expeditor:
     executor:


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
