### PR TITLE
Set solaris as target in chef-apply

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,11 +115,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "solaris4" do |node|
-    node.vm.box =  "plaurin/solaris-11_3"
+    config.vm.box = "MartijnDwars/solaris11_4"
+    config.vm.box_version = "1.0.0"
     node.vm.hostname = "solaris4"
     node.vm.network "private_network", ip: "192.168.33.65"
     node.vm.network :forwarded_port, guest: 22, host: "2235", id: "ssh", auto_correct: true
-    node.ssh.password = "1vagrant"
     node.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
     node.ssh.insert_key = false
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,4 +104,23 @@ Vagrant.configure("2") do |config|
       virtualbox.customize ["setextradata", :id, "VBoxInternal2/EfiGopMode", "4"]
     end
   end
+
+  config.vm.define "solaris" do |node|
+    node.vm.box =  "jonatasbaldin/solaris11"
+    node.vm.hostname = "solaris"
+    node.vm.network "private_network", ip: "192.168.33.62"
+    node.vm.network :forwarded_port, guest: 22, host: "2232", id: "ssh", auto_correct: true
+    node.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+    node.ssh.insert_key = false
+  end
+
+  config.vm.define "solaris4" do |node|
+    node.vm.box =  "plaurin/solaris-11_3"
+    node.vm.hostname = "solaris4"
+    node.vm.network "private_network", ip: "192.168.33.65"
+    node.vm.network :forwarded_port, guest: 22, host: "2235", id: "ssh", auto_correct: true
+    node.ssh.password = "1vagrant"
+    node.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+    node.ssh.insert_key = false
+  end
 end

--- a/lib/chef_apply/action/install_chef.rb
+++ b/lib/chef_apply/action/install_chef.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+require 'byebug'
 require_relative "base"
 require_relative "install_chef/minimum_chef_version"
 require "fileutils" unless defined?(FileUtils)
@@ -98,6 +98,8 @@ module ChefApply
           opts[:platform] = "el"
         when "suse"
           opts[:platform] = "sles"
+        when "solaris"
+          opts[:platform] = "solaris2"
         when "amazon"
           opts[:platform] = "el"
           if platform.release.to_i > 2010 # legacy Amazon version 1

--- a/lib/chef_apply/action/install_chef.rb
+++ b/lib/chef_apply/action/install_chef.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'byebug'
 require_relative "base"
 require_relative "install_chef/minimum_chef_version"
 require "fileutils" unless defined?(FileUtils)

--- a/lib/chef_apply/action/install_chef/minimum_chef_version.rb
+++ b/lib/chef_apply/action/install_chef/minimum_chef_version.rb
@@ -39,7 +39,7 @@ module ChefApply
           solaris: {
               13 => Gem::Version.new("13.10.4"),
               14 => Gem::Version.new("14.1.1"),
-          }
+          },
         }.freeze
 
         def self.check!(target, check_only)

--- a/lib/chef_apply/action/install_chef/minimum_chef_version.rb
+++ b/lib/chef_apply/action/install_chef/minimum_chef_version.rb
@@ -36,6 +36,10 @@ module ChefApply
             13 => Gem::Version.new("13.10.4"),
             14 => Gem::Version.new("14.1.1"),
           },
+          solaris: {
+              10 => Gem::Version.new("10"),
+              11 => Gem::Version.new("11.4"),
+          }
         }.freeze
 
         def self.check!(target, check_only)

--- a/lib/chef_apply/action/install_chef/minimum_chef_version.rb
+++ b/lib/chef_apply/action/install_chef/minimum_chef_version.rb
@@ -37,8 +37,8 @@ module ChefApply
             14 => Gem::Version.new("14.1.1"),
           },
           solaris: {
-              10 => Gem::Version.new("10"),
-              11 => Gem::Version.new("11.4"),
+              13 => Gem::Version.new("13.10.4"),
+              14 => Gem::Version.new("14.1.1"),
           }
         }.freeze
 

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 require "mixlib/cli" unless defined?(Mixlib::CLI)
+require 'byebug'
 
 require_relative "config"
 require "chef-config/config"
@@ -111,6 +112,7 @@ module ChefApply
         validate_params(cli_arguments)
         target_hosts = resolve_targets(cli_arguments.shift, parsed_options)
         render_cookbook_setup(cli_arguments)
+        byebug
         render_converge(target_hosts)
       end
     rescue OptionParser::InvalidOption => e # from parse_options

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 require "mixlib/cli" unless defined?(Mixlib::CLI)
-require 'byebug'
 
 require_relative "config"
 require "chef-config/config"

--- a/lib/chef_apply/cli.rb
+++ b/lib/chef_apply/cli.rb
@@ -112,7 +112,6 @@ module ChefApply
         validate_params(cli_arguments)
         target_hosts = resolve_targets(cli_arguments.shift, parsed_options)
         render_cookbook_setup(cli_arguments)
-        byebug
         render_converge(target_hosts)
       end
     rescue OptionParser::InvalidOption => e # from parse_options

--- a/lib/chef_apply/target_host.rb
+++ b/lib/chef_apply/target_host.rb
@@ -18,8 +18,6 @@
 require_relative "log"
 require_relative "error"
 require "train"
-require 'byebug'
-
 module ChefApply
   class TargetHost
     attr_reader :config, :reporter, :backend, :transport_type

--- a/lib/chef_apply/target_host.rb
+++ b/lib/chef_apply/target_host.rb
@@ -145,7 +145,7 @@ module ChefApply
         require_relative "target_host/solaris"
         class << self; include ChefApply::TargetHost::Solaris; end
       when :other
-      raise ChefApply::TargetHost::UnsupportedTargetOS.new(platform.name)
+        raise ChefApply::TargetHost::UnsupportedTargetOS.new(platform.name)
       end
     end
 

--- a/lib/chef_apply/target_host.rb
+++ b/lib/chef_apply/target_host.rb
@@ -18,6 +18,7 @@
 require_relative "log"
 require_relative "error"
 require "train"
+require 'byebug'
 
 module ChefApply
   class TargetHost
@@ -142,8 +143,11 @@ module ChefApply
       when :macos
         require_relative "target_host/macos"
         class << self; include ChefApply::TargetHost::MacOS; end
+      when :solaris
+        require_relative "target_host/solaris"
+        class << self; include ChefApply::TargetHost::Solaris; end
       when :other
-        raise ChefApply::TargetHost::UnsupportedTargetOS.new(platform.name)
+      raise ChefApply::TargetHost::UnsupportedTargetOS.new(platform.name)
       end
     end
 
@@ -174,6 +178,8 @@ module ChefApply
         :linux
       elsif platform.darwin?
         :macos
+      elsif platform.solaris?
+        :solaris
       else
         :other
       end

--- a/lib/chef_apply/target_host/solaris.rb
+++ b/lib/chef_apply/target_host/solaris.rb
@@ -3,7 +3,6 @@ module ChefApply
     module Solaris
 
       def omnibus_manifest_path
-        # TODO - if habitat install on target, this won't work
         # Note that we can't use File::Join, because that will render for the
         # CURRENT platform - not the platform of the target.
         "/opt/chef/version-manifest.json"
@@ -20,7 +19,7 @@ module ChefApply
       end
 
       def make_temp_dir
-        # We will cache this so that we only
+        # We will cache this so that we only run this once
         @tempdir ||= begin
           res = run_command!("bash -c '#{MKTEMP_COMMAND}'")
           res.stdout.chomp.strip
@@ -28,7 +27,6 @@ module ChefApply
       end
 
       def install_package(target_package_path)
-        # command = "pkgadd  -n -d #{target_package_path} chef"
         command = "pkg install -g #{target_package_path} chef"
         run_command!(command)
       end
@@ -45,7 +43,7 @@ module ChefApply
         "/var/chef-workstation"
       end
 
-      # Nothing to escape in a linux-based path
+      # Nothing to escape in a unix-based path
       def normalize_path(path)
         path
       end

--- a/lib/chef_apply/target_host/solaris.rb
+++ b/lib/chef_apply/target_host/solaris.rb
@@ -1,0 +1,59 @@
+require 'byebug'
+module ChefApply
+  class TargetHost
+    module Solaris
+
+      def omnibus_manifest_path
+        # TODO - if habitat install on target, this won't work
+        # Note that we can't use File::Join, because that will render for the
+        # CURRENT platform - not the platform of the target.
+        "/opt/chef/version-manifest.json"
+      end
+
+      def mkdir(path)
+        run_command!("mkdir -p #{path}")
+      end
+
+      def chown(path, owner)
+        owner ||= user
+        run_command!("chown #{owner} '#{path}'")
+        nil
+      end
+
+      def make_temp_dir
+        # We will cache this so that we only
+        @tempdir ||= begin
+          res = run_command!("bash -c '#{MKTEMP_COMMAND}'")
+          res.stdout.chomp.strip
+        end
+      end
+
+      def install_package(target_package_path)
+        byebug
+        # target_package_path = "/var/spool/pkg"
+        command = "pkgadd  -d #{target_package_path}"
+        run_command!(command)
+      end
+
+      def del_file(path)
+        run_command!("rm -rf #{path}")
+      end
+
+      def del_dir(path)
+        del_file(path)
+      end
+
+      def ws_cache_path
+        "/var/chef-workstation"
+      end
+
+      # Nothing to escape in a linux-based path
+      def normalize_path(path)
+        path
+      end
+
+      MKTEMP_COMMAND = "d=$(mktemp -d -p${TMPDIR:-/tmp} chef_XXXXXX); echo $d".freeze
+
+    end
+  end
+end

--- a/lib/chef_apply/target_host/solaris.rb
+++ b/lib/chef_apply/target_host/solaris.rb
@@ -29,9 +29,8 @@ module ChefApply
       end
 
       def install_package(target_package_path)
-        byebug
-        # target_package_path = "/var/spool/pkg"
-        command = "pkgadd  -d #{target_package_path}"
+        # command = "pkgadd  -n -d #{target_package_path} chef"
+        command = "pkg install -g #{target_package_path} chef"
         run_command!(command)
       end
 

--- a/lib/chef_apply/target_host/solaris.rb
+++ b/lib/chef_apply/target_host/solaris.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 module ChefApply
   class TargetHost
     module Solaris

--- a/lib/chef_apply/ui/terminal.rb
+++ b/lib/chef_apply/ui/terminal.rb
@@ -51,7 +51,6 @@ module ChefApply
           # @option options [Hash] :style
           #   keys :top :middle and :bottom can contain Strings that are used to
           #   indent the spinners. Ignored if message is blank
-          byebug
           multispinner = get_multispinner.new("[:spinner] #{header}",
             output: @location,
             hide_cursor: true,
@@ -59,11 +58,9 @@ module ChefApply
           jobs.each do |job|
             multispinner.register(spinner_prefix(job.prefix), hide_cursor: true) do |spinner|
               reporter = StatusReporter.new(spinner, prefix: job.prefix, key: :status)
-              byebug
               job.run(reporter)
             end
           end
-          byebug
           multispinner.auto_spin
         ensure
           # Spinners hide the cursor for better appearance, so we need to make sure

--- a/lib/chef_apply/ui/terminal.rb
+++ b/lib/chef_apply/ui/terminal.rb
@@ -22,6 +22,7 @@ require_relative "../config"
 require_relative "../log"
 require_relative "plain_text_element"
 require_relative "plain_text_header"
+require 'byebug'
 
 module ChefApply
   module UI
@@ -50,6 +51,7 @@ module ChefApply
           # @option options [Hash] :style
           #   keys :top :middle and :bottom can contain Strings that are used to
           #   indent the spinners. Ignored if message is blank
+          byebug
           multispinner = get_multispinner.new("[:spinner] #{header}",
             output: @location,
             hide_cursor: true,
@@ -57,9 +59,11 @@ module ChefApply
           jobs.each do |job|
             multispinner.register(spinner_prefix(job.prefix), hide_cursor: true) do |spinner|
               reporter = StatusReporter.new(spinner, prefix: job.prefix, key: :status)
+              byebug
               job.run(reporter)
             end
           end
+          byebug
           multispinner.auto_spin
         ensure
           # Spinners hide the cursor for better appearance, so we need to make sure

--- a/lib/chef_apply/ui/terminal.rb
+++ b/lib/chef_apply/ui/terminal.rb
@@ -22,8 +22,6 @@ require_relative "../config"
 require_relative "../log"
 require_relative "plain_text_element"
 require_relative "plain_text_header"
-require 'byebug'
-
 module ChefApply
   module UI
     class Terminal

--- a/spec/unit/target_host/solaris_spec.rb
+++ b/spec/unit/target_host/solaris_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "chef_apply/target_host"
+require "chef_apply/target_host/solaris"
+
+RSpec.describe ChefApply::TargetHost::Linux do
+  let(:user) { "testuser" }
+  let(:host) { "mock://#{user}@example.com" }
+  let(:family) { "solaris" }
+  let(:name) { "solaris" }
+  let(:path) { "/tmp/blah" }
+
+  subject do
+    ChefApply::TargetHost.mock_instance(host, family: family, name: name)
+  end
+
+  context "#make_temp_dir" do
+    it "creates the directory using a properly formed make_temp_dir" do
+      expect(subject).to receive(:run_command!)
+                             .with("bash -c '#{ChefApply::TargetHost::Solaris::MKTEMP_COMMAND}'")
+                             .and_return(instance_double("result", stdout: "/tmp/blah"))
+      expect(subject.make_temp_dir).to eq "/tmp/blah"
+    end
+  end
+
+  context "#mkdir" do
+    it "uses a properly formed mkdir to create the directory and changes ownership to connected user" do
+      expect(subject).to receive(:run_command!).with("mkdir -p /tmp/dir")
+      subject.mkdir("/tmp/dir")
+    end
+  end
+
+  context "#chown" do
+    it "uses a properly formed chown to change owning user to the provided user" do
+      expect(subject).to receive(:run_command!).with("chown newowner '/tmp/dir'")
+      subject.chown("/tmp/dir", "newowner")
+    end
+  end
+
+  context "#install_package" do
+    context "when it receives an RPM package" do
+      # solaris packages to be installed here
+      let(:expected_command) { "rpm -Uvh /my/package.rpm" }
+      it "should run the correct rpm command" do
+        expect(subject).to receive(:run_command!).with expected_command
+        subject.install_package("/my/package.rpm")
+
+      end
+
+    end
+    context "when it receives a DEB package" do
+      let(:expected_command) { "dpkg -i /my/package.deb" }
+      it "should run the correct dpkg command" do
+        expect(subject).to receive(:run_command!).with expected_command
+        subject.install_package("/my/package.deb")
+      end
+    end
+  end
+end

--- a/spec/unit/target_host/solaris_spec.rb
+++ b/spec/unit/target_host/solaris_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe ChefApply::TargetHost::Linux do
   context "#make_temp_dir" do
     it "creates the directory using a properly formed make_temp_dir" do
       expect(subject).to receive(:run_command!)
-                             .with("bash -c '#{ChefApply::TargetHost::Solaris::MKTEMP_COMMAND}'")
-                             .and_return(instance_double("result", stdout: "/tmp/blah"))
+        .with("bash -c '#{ChefApply::TargetHost::Solaris::MKTEMP_COMMAND}'")
+        .and_return(instance_double("result", stdout: "/tmp/blah"))
       expect(subject.make_temp_dir).to eq "/tmp/blah"
     end
   end

--- a/spec/unit/target_host/solaris_spec.rb
+++ b/spec/unit/target_host/solaris_spec.rb
@@ -37,22 +37,14 @@ RSpec.describe ChefApply::TargetHost::Linux do
   end
 
   context "#install_package" do
-    context "when it receives an RPM package" do
-      # solaris packages to be installed here
-      let(:expected_command) { "rpm -Uvh /my/package.rpm" }
-      it "should run the correct rpm command" do
+    context "run the correct pkg run command " do
+      let(:expected_command) { "pkg install -g /my/chef-17.3.48-1.i386.p5p chef" }
+      it "should run the correct install command" do
         expect(subject).to receive(:run_command!).with expected_command
-        subject.install_package("/my/package.rpm")
+        subject.install_package("/my/chef-17.3.48-1.i386.p5p")
 
       end
 
-    end
-    context "when it receives a DEB package" do
-      let(:expected_command) { "dpkg -i /my/package.deb" }
-      it "should run the correct dpkg command" do
-        expect(subject).to receive(:run_command!).with expected_command
-        subject.install_package("/my/package.deb")
-      end
     end
   end
 end

--- a/spec/unit/target_host/solaris_spec.rb
+++ b/spec/unit/target_host/solaris_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "chef_apply/target_host"
 require "chef_apply/target_host/solaris"
 
-RSpec.describe ChefApply::TargetHost::Linux do
+RSpec.describe ChefApply::TargetHost::Solaris do
   let(:user) { "testuser" }
   let(:host) { "mock://#{user}@example.com" }
   let(:family) { "solaris" }


### PR DESCRIPTION

## Description
Allows Solaris hosts as a target for chef-apply 

## Related Issue
https://github.com/chef/chef-apply/issues/156

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
