### PR TITLE
Fix permission issue for running coverage workflow

### DIFF
--- a/.github/workflows/coverage_workflow.yaml
+++ b/.github/workflows/coverage_workflow.yaml
@@ -1,0 +1,21 @@
+name: Label when run coverage
+on: 
+  workflow_run:
+    workflows: ["run test"]
+    types: ['requested']
+
+permissions:
+  # All other permissions are set to none
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-when-run-coverage:
+    name: "Label PR wehen run test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Do nothing. Only trigger corresponding workflow_run event"
+        run: echo
+
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,22 +34,3 @@ jobs:
         with:
           config: cspell.json
           paths: "**/*"
-
-  coverage-test:
-    name: Coverage
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up ruby 2.7
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - name: run specs
-        run: bundle exec rake spec --trace
-      - name: Simplecov Report
-        uses: aki77/simplecov-report-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failedThreshold: 90
-          resultPath: coverage/.last_run.json 

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,0 +1,28 @@
+---
+name: run test
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  coverage-test:
+    name: Coverage
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: run specs
+        run: bundle exec rake spec --trace
+      - name: Simplecov Report
+        uses: aki77/simplecov-report-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failedThreshold: 90
+          resultPath: coverage/.last_run.json 

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,11 +1,17 @@
 ---
 name: run test
 
-"on":
+on:
   pull_request:
   push:
     branches:
       - main
+
+permissions:
+  # All other permissions are set to none
+  checks: write
+  contents: read
+  pull-requests: write
 
 jobs:
   coverage-test:


### PR DESCRIPTION
Signed-off-by: snehaldwivedi <sdwivedi@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
bug: Error: Resource not accessible by integration. It is related to limited permissions of workflows being triggered by pull_request_review (GITHUB_TOKEN has read-only permissions). More information about it you can find in the article: [Keeping your GitHub Actions and workflows secure: Preventing pwn requests.](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
